### PR TITLE
fix: create admin_policy_acceptance table with unique constraint

### DIFF
--- a/migrations/0003_admin_policy_acceptance.sql
+++ b/migrations/0003_admin_policy_acceptance.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "admin_policy_acceptance" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"admin_id" varchar NOT NULL,
+	"timestamp" timestamp DEFAULT now() NOT NULL,
+	"policy_version" varchar NOT NULL,
+	"terms_version" varchar NOT NULL,
+	"privacy_version" varchar NOT NULL,
+	"accepted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "admin_policy_acceptance_unique_idx" ON "admin_policy_acceptance" ("admin_id","policy_version","terms_version","privacy_version");

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1774969601003,
       "tag": "0002_lumpy_living_tribunal",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1744012800000,
+      "tag": "0003_admin_policy_acceptance",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { integer, jsonb, pgTable, text, timestamp, varchar, boolean } from "drizzle-orm/pg-core";
+import { integer, jsonb, pgTable, text, timestamp, varchar, boolean, uniqueIndex } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -181,6 +181,38 @@ export const personalInformation = pgTable("personal_information", {
 
 export const insertPersonalInformationSchema = createInsertSchema(personalInformation).omit({ id: true, updatedAt: true });
 export const updatePersonalInformationSchema = insertPersonalInformationSchema.partial();
+
+export const adminPolicyAcceptance = pgTable(
+  "admin_policy_acceptance",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    adminId: varchar("admin_id").notNull(),
+    timestamp: timestamp("timestamp").defaultNow().notNull(),
+    policyVersion: varchar("policy_version").notNull(),
+    termsVersion: varchar("terms_version").notNull(),
+    privacyVersion: varchar("privacy_version").notNull(),
+    accepted: boolean("accepted").notNull().default(false),
+  },
+  (table) => [
+    uniqueIndex("admin_policy_acceptance_unique_idx").on(
+      table.adminId,
+      table.policyVersion,
+      table.termsVersion,
+      table.privacyVersion,
+    ),
+  ],
+);
+
+export const insertAdminPolicyAcceptanceSchema = createInsertSchema(adminPolicyAcceptance).pick({
+  adminId: true,
+  policyVersion: true,
+  termsVersion: true,
+  privacyVersion: true,
+  accepted: true,
+});
+
+export type AdminPolicyAcceptance = typeof adminPolicyAcceptance.$inferSelect;
+export type InsertAdminPolicyAcceptance = typeof insertAdminPolicyAcceptanceSchema._type;
 
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;

--- a/shared/schema_policy.ts
+++ b/shared/schema_policy.ts
@@ -1,24 +1,7 @@
-import { sql } from "drizzle-orm";
-import { varchar, boolean, timestamp, pgTable } from "drizzle-orm/pg-core";
-import { createInsertSchema } from "drizzle-zod";
-
-export const adminPolicyAcceptance = pgTable("admin_policy_acceptance", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  adminId: varchar("admin_id").notNull(),
-  timestamp: timestamp("timestamp").defaultNow().notNull(),
-  policyVersion: varchar("policy_version").notNull(),
-  termsVersion: varchar("terms_version").notNull(),
-  privacyVersion: varchar("privacy_version").notNull(),
-  accepted: boolean("accepted").notNull().default(false),
-});
-
-export const insertAdminPolicyAcceptanceSchema = createInsertSchema(adminPolicyAcceptance).pick({
-  adminId: true,
-  policyVersion: true,
-  termsVersion: true,
-  privacyVersion: true,
-  accepted: true,
-});
-
-export type AdminPolicyAcceptance = typeof adminPolicyAcceptance.$inferSelect;
-export type InsertAdminPolicyAcceptance = typeof insertAdminPolicyAcceptanceSchema._type;
+// Re-exported from schema.ts where the table is now properly tracked by drizzle-kit
+export {
+  adminPolicyAcceptance,
+  insertAdminPolicyAcceptanceSchema,
+  type AdminPolicyAcceptance,
+  type InsertAdminPolicyAcceptance,
+} from "./schema";


### PR DESCRIPTION
The table was defined in schema_policy.ts which was excluded from
drizzle.config.ts, so it was never created in the DB. The missing
table caused the POST /api/admin/policy/accept route to fail, which
meant setPolicyAccepted(true) was never called after clicking agree,
leaving the user stuck on the acceptance modal.

Fixes:
- Move adminPolicyAcceptance table definition into schema.ts so
  drizzle-kit push creates it
- Add a unique index on (adminId, policyVersion, termsVersion,
  privacyVersion) required for onConflictDoUpdate to work correctly
- Reduce schema_policy.ts to a re-export shim to keep existing
  imports working
- Add migration 0003 for the new table and unique index

https://claude.ai/code/session_01PC7zMoCnK42WtCo1wSsv8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system to track administrator acceptance of policies, terms of service, and privacy policies with version tracking and audit timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->