### PR TITLE
refactor(tracking): replace arbitrary query-param tracking with UUID-…

### DIFF
--- a/legal/PRIVACY_POLICY.md
+++ b/legal/PRIVACY_POLICY.md
@@ -1,7 +1,7 @@
 # Privacy Policy
 
-**Last Updated:** May 14, 2026  
-**Effective Date:** May 14, 2026
+**Last Updated:** May 19, 2026  
+**Effective Date:** May 19, 2026
 
 ## 1. Introduction
 
@@ -21,14 +21,17 @@ The Site is operated primarily for users located in the United States and may re
 
 ### 3.1 Data Collected from All Visitors
 
-When you visit the Site, we automatically collect the following data through our session replay and analytics service (LogRocket):
+**For all visitors (regardless of consent):**
 
-- **Navigation Data:** Page path, route names, and query parameters in your URL.
-- **Session Data:** A unique anonymous session identifier stored in your browser's localStorage.
-- **IP Address:** Your client IP address (collected and sent to LogRocket).
+- **Persistent Browser Identifier (`tr_uuid` cookie):** A randomly generated, anonymized identifier is set in a cookie on every visit. It never expires. Without consent, this identifier is not linked to any behavioral or analytics data.
+- **IP Address & Request Timestamps:** Your IP address and the time of each API request are logged for security and rate-limiting purposes. This log is minimal and is not used for behavioral analytics.
+
+**Additionally, when you have granted analytics consent**, we collect the following through LogRocket:
+
+- **Navigation Data:** Page paths and route names you visit (query parameters are not forwarded to LogRocket).
+- **Session Replay:** A replay of your interactions including clicks, scrolling, form inputs (with masking), page load times, and errors.
 - **Device & Browser Data:** Browser type, OS, device type, screen resolution, and user agent.
-- **Interaction Data:** Clicks, scrolling, user inputs (with masking applied), page load times, and errors.
-- **Timestamps:** When you visit and interact with the Site.
+- **IP Address:** Also forwarded to LogRocket for geolocation and session enrichment.
 
 ### 3.2 Data Collected from Authenticated Admin Users
 
@@ -50,9 +53,10 @@ When authenticated admin users create, edit, or delete portfolio content, we log
 
 We use the following cookie categories:
 
+- **Persistent Identifier Cookie (`tr_uuid`):** Set on every visit regardless of consent. Contains a randomly generated anonymous identifier. Duration: Does not expire (set with a long-lived max-age). This cookie is used for security logging for all visitors and, if you consent, for analytics session association.
 - **Essential/Strictly Necessary Cookies:** Session cookies for authentication and CSRF protection. Duration: Session or until logged out.
 - **Preference Cookies:** `sidebar_state` cookie to remember your UI preferences (sidebar open/closed). Duration: 7 days.
-- **Analytics Cookies:** Set by LogRocket for session replay tracking and analytics. Duration: Managed by LogRocket according to their default retention policies.
+- **Analytics Cookies:** Set by LogRocket for session replay tracking and analytics (consent required). Duration: Managed by LogRocket according to their default retention policies.
 
 ### 3.5 Data Not Collected
 
@@ -113,7 +117,7 @@ Depending on your jurisdiction, you may have the right to:
 
 ### Browser-Level Control
 
-- **Clear Cookies & Storage:** You can delete the `sidebar_state` cookie and `__lr_anon_id` localStorage key using your browser's settings.
+- **Clear Cookies & Storage:** You can delete the `tr_uuid` and `sidebar_state` cookies using your browser's settings (Settings → Privacy → Cookies / Site Data). Note that deleting `tr_uuid` will cause a new identifier to be issued on your next visit.
 - **Disable JavaScript:** Disabling JavaScript will prevent LogRocket from loading and tracking.
 
 ### Session Replay Opt-In

--- a/legal/TRACKING_NOTICE_AND_CONSENT.md
+++ b/legal/TRACKING_NOTICE_AND_CONSENT.md
@@ -1,7 +1,7 @@
 # Tracking Notice & Consent Policy
 
-**Last Updated:** March 27, 2026  
-**Effective Date:** March 27, 2026
+**Last Updated:** May 19, 2026  
+**Effective Date:** May 19, 2026
 
 ## 1. What We Track
 
@@ -26,16 +26,23 @@ We have configured LogRocket to **not** record:
 - Password fields, credit card data, or other explicitly masked input fields.
 - Audio or video content.
 - Content from third-party embedded iframes (with limited exceptions).
-
-However, **general URL paths and query parameters may be recorded even if they could contain sensitive data.** Users should avoid placing sensitive information in URLs.
+- **URL query parameters** — query strings are stripped before events are sent to LogRocket.
 
 ### 1.3 Cookie & Storage
 
 We use browser storage technologies to track your activity:
 
-- **localStorage:** We store a unique anonymous identifier (`__lr_anon_id`) to associate your session with LogRocket data.
+- **Persistent Identifier Cookie (`tr_uuid`):** A randomly generated, anonymized identifier cookie is set on every visit. It never expires and is used to associate your sessions across visits. This cookie is set regardless of consent; however, it is only used for analytics or linked to your activity in our systems when you have granted consent. Without consent it serves only as a structural anchor for security logging (see Section 1.4).
 - **Cookies:** We store a `sidebar_state` cookie to remember your UI preferences (sidebar open/closed).
 - **Session Cookies:** For authenticated admin users, we store session cookies for authentication.
+
+### 1.4 Security & Rate-Limit Logging
+
+Regardless of your consent choice, we log your IP address and the time of each request to the Site's API for security and rate-limiting purposes. This log is minimal (IP, request path, timestamp) and is not used for behavioral analytics. When you have granted analytics consent, these log entries are linked to your persistent identifier (`tr_uuid`); otherwise they are stored anonymously.
+
+### 1.5 Campaign Source Tracking
+
+If you arrive at the Site via a link containing a campaign reference parameter, and you have granted analytics consent, we may record that campaign source in our systems to understand how visitors discover the Site. No personally identifiable information is collected through this mechanism. If you have not granted consent, the parameter is discarded without being recorded.
 
 ## 2. Categories of Tracking
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -6,7 +6,7 @@ import { createServer } from "http";
 import { setupAuth } from "./auth";
 import { detectCountryFromIP, extractClientIp, isLocalIp } from "./geoip";
 import { warmLinkedinActivityCache } from "./linkedin";
-import { uuidCookieMiddleware, requestLogMiddleware } from "./tracking";
+import { uuidCookieMiddleware, requestLogMiddleware, ipRateLogMiddleware } from "./tracking";
 
 const app = express();
 const httpServer = createServer(app);
@@ -29,6 +29,7 @@ app.use(express.urlencoded({ extended: false }));
 setupAuth(app);
 app.use(uuidCookieMiddleware);
 app.use(requestLogMiddleware);
+app.use(ipRateLogMiddleware);
 
 const enforceUsOnly = process.env.ENFORCE_US_ONLY !== "false";
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -6,6 +6,7 @@ import { createServer } from "http";
 import { setupAuth } from "./auth";
 import { detectCountryFromIP, extractClientIp, isLocalIp } from "./geoip";
 import { warmLinkedinActivityCache } from "./linkedin";
+import { uuidCookieMiddleware, requestLogMiddleware } from "./tracking";
 
 const app = express();
 const httpServer = createServer(app);
@@ -26,6 +27,8 @@ app.use(
 
 app.use(express.urlencoded({ extended: false }));
 setupAuth(app);
+app.use(uuidCookieMiddleware);
+app.use(requestLogMiddleware);
 
 const enforceUsOnly = process.env.ENFORCE_US_ONLY !== "false";
 

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "http";
 import { createHash } from "crypto";
 import { authRoutes, requireAdmin, requireAuth } from "./auth";
 import { db } from "./data/db";
+import { getRequestTrackerUuid, registerTrackedUuid, upsertTrEn } from "./tracking";
 import { detectCountryFromIP, extractClientIp } from "./geoip";
 import { loadLegalDoc } from "./markdown";
 import { getGithubActivity, getGithubTimeline } from "./github";
@@ -642,12 +643,19 @@ export async function registerRoutes(
         content: String(m.content).slice(0, 4000),
       }));
 
+    const trackerUuid = getRequestTrackerUuid(req);
     const chatRun = createRun({
       name: welcome ? "welcome-summary" : "project-chat",
       runType: "chain",
       inputs: { messages: userMessages },
       tags: ["project-chat", modelId, provider.constructor.name, project.title],
-      metadata: { projectId: project.id, projectTitle: project.title, provider: provider.constructor.name, modelId },
+      metadata: {
+        projectId: project.id,
+        projectTitle: project.title,
+        provider: provider.constructor.name,
+        modelId,
+        ...(trackerUuid ? { trackerUuid } : {}),
+      },
     });
     if (chatRun) await chatRun.postRun().catch(() => {});
 
@@ -972,6 +980,31 @@ export async function registerRoutes(
       ? forwarded[0]
       : forwarded?.split(",")[0]?.trim() || req.ip;
     res.json({ ip });
+  });
+
+  // ========== BROWSER TRACKING ==========
+  app.post("/api/public/tracking/init", async (req, res) => {
+    const uuid = getRequestTrackerUuid(req);
+    if (!uuid) return res.status(400).json({ error: "No tracking cookie present" });
+
+    const ip =
+      (req.headers["x-client-ip"] as string | undefined) ||
+      extractClientIp(req) ||
+      undefined;
+
+    await registerTrackedUuid(uuid, ip);
+    return res.json({ ok: true });
+  });
+
+  app.post("/api/public/tracking/tr-en", async (req, res) => {
+    const uuid = getRequestTrackerUuid(req);
+    if (!uuid) return res.status(400).json({ error: "No tracking cookie present" });
+
+    const trEn = typeof req.body?.trEn === "string" ? req.body.trEn.slice(0, 256) : null;
+    if (!trEn) return res.status(400).json({ error: "trEn value required" });
+
+    await upsertTrEn(uuid, trEn);
+    return res.json({ ok: true });
   });
 
   app.get("/api/admin/projects", requireAdmin, async (_req, res) => {

--- a/src/backend/tracking-utils.ts
+++ b/src/backend/tracking-utils.ts
@@ -1,0 +1,23 @@
+import { createHash, randomUUID } from "crypto";
+import type { Request } from "express";
+
+export const TRACKER_COOKIE_NAME = "tr_uuid";
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(";")) {
+    const sep = part.indexOf("=");
+    if (sep < 1) continue;
+    out[part.slice(0, sep).trim()] = decodeURIComponent(part.slice(sep + 1).trim());
+  }
+  return out;
+}
+
+export function generateHashedUuid(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+
+export function getRequestTrackerUuid(req: Request): string | undefined {
+  return parseCookies(req.headers.cookie)[TRACKER_COOKIE_NAME];
+}

--- a/src/backend/tracking-utils.ts
+++ b/src/backend/tracking-utils.ts
@@ -3,6 +3,12 @@ import type { Request } from "express";
 
 export const TRACKER_COOKIE_NAME = "tr_uuid";
 
+export type TrackingIpCache = Map<string, string>;
+
+export function makeTrackingIpCacheKey(uuid: string, ip: string): string {
+  return `${uuid}::${ip}`;
+}
+
 export function parseCookies(header: string | undefined): Record<string, string> {
   const out: Record<string, string> = {};
   if (!header) return out;

--- a/src/backend/tracking.ts
+++ b/src/backend/tracking.ts
@@ -1,0 +1,126 @@
+import type { Request, Response, NextFunction } from "express";
+import { db } from "./data/db";
+import { browserTracking, browserTrackingIps, browserRequestLogs } from "@shared/schema";
+import { extractClientIp } from "./geoip";
+import { eq } from "drizzle-orm";
+import {
+  TRACKER_COOKIE_NAME,
+  parseCookies,
+  generateHashedUuid,
+  getRequestTrackerUuid,
+} from "./tracking-utils";
+
+export { TRACKER_COOKIE_NAME, generateHashedUuid, getRequestTrackerUuid } from "./tracking-utils";
+
+const COOKIE_MAX_AGE_MS = 10 * 365 * 24 * 60 * 60 * 1000; // 10 years
+
+const isProd = process.env.NODE_ENV === "production";
+
+export function uuidCookieMiddleware(req: Request, res: Response, next: NextFunction) {
+  const cookies = parseCookies(req.headers.cookie);
+  let uuid = cookies[TRACKER_COOKIE_NAME];
+
+  if (!uuid) {
+    uuid = generateHashedUuid();
+    res.cookie(TRACKER_COOKIE_NAME, uuid, {
+      maxAge: COOKIE_MAX_AGE_MS,
+      httpOnly: false,
+      sameSite: "lax",
+      secure: isProd,
+      path: "/",
+    });
+  }
+
+  (req as any).trackerUuid = uuid;
+  next();
+}
+
+// Minimal TTL cache so we avoid a DB hit on every request after consent.
+const trackedUuidsCache = new Map<string, { tracked: boolean; expires: number }>();
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+async function isUuidTracked(uuid: string): Promise<boolean> {
+  const cached = trackedUuidsCache.get(uuid);
+  if (cached && cached.expires > Date.now()) return cached.tracked;
+
+  try {
+    const [row] = await db
+      .select({ id: browserTracking.id })
+      .from(browserTracking)
+      .where(eq(browserTracking.hashedUuid, uuid))
+      .limit(1);
+
+    const tracked = !!row;
+    trackedUuidsCache.set(uuid, { tracked, expires: Date.now() + CACHE_TTL_MS });
+    return tracked;
+  } catch {
+    return false;
+  }
+}
+
+export function requestLogMiddleware(req: Request, res: Response, next: NextFunction) {
+  if (!req.path.startsWith("/api")) return next();
+
+  const uuid = (req as any).trackerUuid as string | undefined;
+  if (!uuid) return next();
+
+  const start = Date.now();
+  const ip =
+    (req.headers["x-client-ip"] as string | undefined) ||
+    extractClientIp(req) ||
+    undefined;
+
+  res.on("finish", () => {
+    isUuidTracked(uuid).then((tracked) => {
+      if (!tracked) return;
+      db.insert(browserRequestLogs)
+        .values({
+          hashedUuid: uuid,
+          ip,
+          method: req.method,
+          path: req.path,
+          statusCode: res.statusCode,
+          durationMs: Date.now() - start,
+          meta: {},
+        })
+        .catch(() => {});
+    }).catch(() => {});
+  });
+
+  next();
+}
+
+export async function registerTrackedUuid(uuid: string, ip: string | undefined): Promise<void> {
+  const now = new Date();
+
+  await db
+    .insert(browserTracking)
+    .values({ hashedUuid: uuid, consentedAt: now })
+    .onConflictDoUpdate({
+      target: [browserTracking.hashedUuid],
+      set: { consentedAt: now, updatedAt: now },
+    });
+
+  trackedUuidsCache.set(uuid, { tracked: true, expires: Date.now() + CACHE_TTL_MS });
+
+  if (ip) {
+    await db
+      .insert(browserTrackingIps)
+      .values({ hashedUuid: uuid, ip, firstSeenAt: now, lastSeenAt: now })
+      .onConflictDoUpdate({
+        target: [browserTrackingIps.hashedUuid, browserTrackingIps.ip],
+        set: { lastSeenAt: now },
+      });
+  }
+}
+
+export async function upsertTrEn(uuid: string, trEn: string): Promise<void> {
+  const now = new Date();
+  await db
+    .insert(browserTracking)
+    .values({ hashedUuid: uuid, trEn })
+    .onConflictDoUpdate({
+      target: [browserTracking.hashedUuid],
+      set: { trEn, updatedAt: now },
+    });
+}

--- a/src/backend/tracking.ts
+++ b/src/backend/tracking.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { db } from "./data/db";
-import { browserTracking, browserTrackingIps, browserRequestLogs } from "@shared/schema";
+import { browserTracking, browserTrackingIps, browserRequestLogs, ipRateLogs } from "@shared/schema";
 import { extractClientIp } from "./geoip";
 import { eq } from "drizzle-orm";
 import {
@@ -8,9 +8,14 @@ import {
   parseCookies,
   generateHashedUuid,
   getRequestTrackerUuid,
+  makeTrackingIpCacheKey,
 } from "./tracking-utils";
 
 export { TRACKER_COOKIE_NAME, generateHashedUuid, getRequestTrackerUuid } from "./tracking-utils";
+
+// Keyed by makeTrackingIpCacheKey(uuid, ip) → browser_tracking_ips.id
+// Populated by registerTrackedUuid; no expiry (the mapping is permanent once consented).
+const trackingIpIdCache = new Map<string, string>();
 
 const COOKIE_MAX_AGE_MS = 10 * 365 * 24 * 60 * 60 * 1000; // 10 years
 
@@ -104,13 +109,18 @@ export async function registerTrackedUuid(uuid: string, ip: string | undefined):
   trackedUuidsCache.set(uuid, { tracked: true, expires: Date.now() + CACHE_TTL_MS });
 
   if (ip) {
-    await db
+    const [tipRow] = await db
       .insert(browserTrackingIps)
       .values({ hashedUuid: uuid, ip, firstSeenAt: now, lastSeenAt: now })
       .onConflictDoUpdate({
         target: [browserTrackingIps.hashedUuid, browserTrackingIps.ip],
         set: { lastSeenAt: now },
-      });
+      })
+      .returning({ id: browserTrackingIps.id });
+
+    if (tipRow?.id) {
+      trackingIpIdCache.set(makeTrackingIpCacheKey(uuid, ip), tipRow.id);
+    }
   }
 }
 
@@ -123,4 +133,33 @@ export async function upsertTrEn(uuid: string, trEn: string): Promise<void> {
       target: [browserTracking.hashedUuid],
       set: { trEn, updatedAt: now },
     });
+}
+
+// Logs every API request by IP regardless of consent, with an optional FK to
+// browser_tracking_ips when the UUID is known and consented (for rate-limit queries
+// that can optionally join into the full UUID graph for consented users).
+export function ipRateLogMiddleware(req: Request, res: Response, next: NextFunction) {
+  if (!req.path.startsWith("/api")) return next();
+
+  const ip =
+    (req.headers["x-client-ip"] as string | undefined) ||
+    extractClientIp(req) ||
+    undefined;
+
+  if (!ip) return next();
+
+  const uuid = (req as any).trackerUuid as string | undefined;
+  const method = req.method;
+  const path = req.path;
+
+  res.on("finish", () => {
+    const trackingIpId =
+      uuid && ip ? (trackingIpIdCache.get(makeTrackingIpCacheKey(uuid, ip)) ?? null) : null;
+
+    db.insert(ipRateLogs)
+      .values({ ip, method, path, statusCode: res.statusCode, trackingIpId })
+      .catch(() => {});
+  });
+
+  next();
 }

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -22,7 +22,8 @@ import About from "@/pages/About";
 import Privacy from "@/pages/Privacy";
 import Terms from "@/pages/Terms";
 import Tracking from "@/pages/Tracking";
-import { attachLogRocketIp, identifyLogRocketUser, trackLogRocketRoute } from "@/lib/logrocket";
+import { attachLogRocketIp, identifyLogRocketUser, trackLogRocketRoute, emitLogRocketUuidEvent } from "@/lib/logrocket";
+import { initBrowserTracking, storeTrEn } from "@/lib/tracking";
 
 function LogRocketBridge() {
   const [location] = useLocation();
@@ -32,7 +33,6 @@ function LogRocketBridge() {
     queryFn: getQueryFn({ on401: "returnNull" }),
   });
 
-  // Listen for consent changes via ConsentManager callback
   useEffect(() => {
     const handleConsentChange = () => {
       setConsentGranted(true);
@@ -42,11 +42,11 @@ function LogRocketBridge() {
   }, []);
 
   useEffect(() => {
-    trackLogRocketRoute(location, window.location.search);
+    trackLogRocketRoute(location);
   }, [location, consentGranted]);
 
   useEffect(() => {
-    const emit = () => trackLogRocketRoute(window.location.pathname, window.location.search);
+    const emit = () => trackLogRocketRoute(window.location.pathname);
     window.addEventListener("popstate", emit);
     window.addEventListener("hashchange", emit);
     return () => {
@@ -62,6 +62,53 @@ function LogRocketBridge() {
   useEffect(() => {
     attachLogRocketIp();
   }, [consentGranted]);
+
+  return null;
+}
+
+// Initializes browser-side UUID tracking (DB + LogRocket) after consent is established.
+function TrackingBridge() {
+  const [consentGranted, setConsentGranted] = useState(() => {
+    const c = getStoredConsent();
+    return c !== null && c.user_action !== "reject_all";
+  });
+
+  useEffect(() => {
+    const handle = () => setConsentGranted(true);
+    window.addEventListener("consent-granted", handle);
+    return () => window.removeEventListener("consent-granted", handle);
+  }, []);
+
+  useEffect(() => {
+    if (!consentGranted) return;
+    initBrowserTracking();
+    emitLogRocketUuidEvent();
+  }, [consentGranted]);
+
+  return null;
+}
+
+// Detects tr_en= on any page, stores (if consented), then strips param and reloads.
+function TrEnProcessor() {
+  const [location] = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const trEn = params.get("tr_en");
+    if (!trEn) return;
+
+    params.delete("tr_en");
+    const newSearch = params.toString();
+    const cleanUrl =
+      window.location.pathname +
+      (newSearch ? `?${newSearch}` : "") +
+      window.location.hash;
+
+    // storeTrEn is a no-op if user hasn't consented
+    storeTrEn(trEn).finally(() => {
+      window.location.replace(cleanUrl);
+    });
+  }, [location]);
 
   return null;
 }
@@ -85,10 +132,8 @@ function ConsentManager({ disabled = false }: { disabled?: boolean }) {
       const hasConsent = getStoredConsent() !== null;
       const globalOptOut = isGlobalOptOutEnabled();
 
-      // Don't show banner on legal doc pages
       const isLegalPage = ["/privacy", "/terms", "/tracking"].includes(location);
 
-      // Respect browser-level privacy controls.
       if (globalOptOut) {
         setShowBanner(false);
         setIsLoaded(true);
@@ -96,13 +141,10 @@ function ConsentManager({ disabled = false }: { disabled?: boolean }) {
       }
 
       const shouldShow = !hasConsent && !isLegalPage;
-      
       setShowBanner(shouldShow);
       setIsLoaded(true);
     })();
   }, [disabled, location]);
-
-
 
   if (!isLoaded) return null;
 
@@ -149,8 +191,10 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
+        <TrEnProcessor />
         <ConsentManager disabled={consentDisabled} />
         <LogRocketBridge />
+        <TrackingBridge />
         <Toaster />
         <Router />
         {showIntro && location === "/" && (

--- a/src/client/src/components/ProjectChat.tsx
+++ b/src/client/src/components/ProjectChat.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { X, Send, Bot, ChevronDown, Square } from "lucide-react";
 import ChatMarkdown from "./ChatMarkdown";
+import { getTrackerUuid } from "@/lib/tracking";
 
 function TypingIndicator() {
   return (
@@ -411,10 +412,16 @@ export default function ProjectChat({ project, onClose, standalone = false }: Pr
     abortRef.current = controller;
 
     try {
+      const trackerUuid = getTrackerUuid();
       const res = await fetch("/api/public/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ projectId: project.id, modelId: selectedModelId, messages: nextMessages }),
+        body: JSON.stringify({
+          projectId: project.id,
+          modelId: selectedModelId,
+          messages: nextMessages,
+          ...(trackerUuid ? { trackerUuid } : {}),
+        }),
         signal: controller.signal,
       });
 
@@ -449,10 +456,17 @@ export default function ProjectChat({ project, onClose, standalone = false }: Pr
     const controller = new AbortController();
     abortRef.current = controller;
     try {
+      const trackerUuid = getTrackerUuid();
       const res = await fetch("/api/public/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ projectId: project.id, modelId: selectedModelId, messages: [{ role: "user", content: "__welcome__" }], welcome: true }),
+        body: JSON.stringify({
+          projectId: project.id,
+          modelId: selectedModelId,
+          messages: [{ role: "user", content: "__welcome__" }],
+          welcome: true,
+          ...(trackerUuid ? { trackerUuid } : {}),
+        }),
         signal: controller.signal,
       });
       if (!res.ok) return;

--- a/src/client/src/lib/logrocket.ts
+++ b/src/client/src/lib/logrocket.ts
@@ -1,5 +1,6 @@
 import LogRocket from "logrocket";
 import { isTrackingAllowed } from "./consent";
+import { getTrackerUuid, getClientIp } from "./tracking";
 
 type MaybeUser = {
   id?: string;
@@ -10,10 +11,10 @@ type MaybeUser = {
 
 let initialized = false;
 let lastRoute = "";
-let lastSearch = "";
 let lastIdentity = "";
 let currentLogRocketUserId = "";
 let ipAttached = false;
+let uuidEmitted = false;
 
 const SENSITIVE_ROUTE_PREFIXES = ["/admin", "/auth/google/callback"];
 
@@ -33,24 +34,9 @@ function recordLogRocketTestEvent(event: string, payload?: Record<string, unknow
   window.__LOGROCKET_TEST_EVENTS.push({ event, payload });
 }
 
-function getAnonymousId() {
-  if (typeof window === "undefined") return "";
-
-  const key = "__lr_anon_id";
-  const existing = window.localStorage.getItem(key);
-  if (existing) return existing;
-
-  const generated = `anon_${Math.random().toString(36).slice(2)}_${Date.now().toString(36)}`;
-  window.localStorage.setItem(key, generated);
-  return generated;
-}
-
 export function initLogRocket() {
-  if (initialized || typeof window === "undefined") {
-    return;
-  }
+  if (initialized || typeof window === "undefined") return;
 
-  // Check consent before initializing LogRocket
   if (!isTrackingAllowed()) {
     recordLogRocketTestEvent("blocked", { reason: "consent" });
     return;
@@ -63,9 +49,7 @@ export function initLogRocket() {
   }
 
   LogRocket.init("ltznbv/portfolio");
-  
   console.log("interest logging started");
-  
   LogRocket.getSessionURL((url) => {
     (window as any).__logrocketSessionURL = url;
   });
@@ -75,12 +59,8 @@ export function initLogRocket() {
 
 export function identifyLogRocketUser(user: MaybeUser) {
   if (typeof window === "undefined") return;
-  
-  // Skip if tracking not allowed
-  if (!isTrackingAllowed()) {
-    return;
-  }
-  
+  if (!isTrackingAllowed()) return;
+
   initLogRocket();
 
   if (user?.id) {
@@ -95,103 +75,87 @@ export function identifyLogRocketUser(user: MaybeUser) {
     LogRocket.identify(user.id, traits);
     lastIdentity = identity;
     currentLogRocketUserId = user.id;
+    emitLogRocketUuidEvent();
     return;
   }
 
-  const anonId = getAnonymousId();
+  const uuid = getTrackerUuid();
+  const anonId = uuid ?? `anon_${Date.now().toString(36)}`;
   const identity = `anon:${anonId}`;
   if (identity === lastIdentity) return;
 
-  LogRocket.identify(identity, {
-    role: "guest",
-  });
+  LogRocket.identify(identity, { role: "guest" });
   lastIdentity = identity;
   currentLogRocketUserId = identity;
+  emitLogRocketUuidEvent();
 }
 
-function parseQuery(search: string) {
-  const params = new URLSearchParams(search.startsWith("?") ? search : `?${search}`);
-  const out: Record<string, string> = {};
-  params.forEach((value, key) => {
-    out[key] = value;
-  });
-  return out;
-}
-
-export function trackLogRocketRoute(path: string, search = "") {
+export function emitLogRocketUuidEvent() {
   if (typeof window === "undefined") return;
+  if (!isTrackingAllowed()) return;
+  if (uuidEmitted) return;
 
-  // Skip if tracking not allowed
-  if (!isTrackingAllowed()) {
+  const uuid = getTrackerUuid();
+  if (!uuid) return;
+
+  uuidEmitted = true;
+
+  if (window.__LOGROCKET_TEST_MODE) {
+    recordLogRocketTestEvent("user_uuid", { uuid });
     return;
   }
+
+  if (initialized) {
+    LogRocket.track("user_uuid", { uuid });
+  }
+}
+
+export function trackLogRocketRoute(path: string) {
+  if (typeof window === "undefined") return;
+  if (!isTrackingAllowed()) return;
 
   initLogRocket();
 
   if (!path) return;
-  if (SENSITIVE_ROUTE_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+  if (SENSITIVE_ROUTE_PREFIXES.some((prefix) => path.startsWith(prefix))) return;
+  if (path === lastRoute) return;
+
+  lastRoute = path;
+
+  if (window.__LOGROCKET_TEST_MODE) {
+    recordLogRocketTestEvent("route_change", { path });
     return;
   }
 
-  const normalizedSearch = search || "";
-
-  if (path === lastRoute && normalizedSearch === lastSearch) return;
-  lastRoute = path;
-  lastSearch = normalizedSearch;
-
-  const query = parseQuery(normalizedSearch);
-  const hasQuery = Object.keys(query).length > 0;
-  const queryJson = JSON.stringify(query);
-
   LogRocket.track("route_change", {
     path,
-    query: queryJson,
-    rawQuery: normalizedSearch,
     at: new Date().toISOString(),
   });
-
-  if (hasQuery) {
-    LogRocket.track("query_params", {
-      endpoint: path,
-      query: queryJson,
-      rawQuery: normalizedSearch,
-      at: new Date().toISOString(),
-    });
-  }
 }
 
 export async function attachLogRocketIp() {
   if (typeof window === "undefined" || ipAttached) return;
-
-  // Skip if tracking not allowed
-  if (!isTrackingAllowed()) {
-    return;
-  }
+  if (!isTrackingAllowed()) return;
 
   initLogRocket();
 
   try {
-    const res = await fetch("/api/public/ip", { credentials: "include" });
-    if (!res.ok) return;
-
-    const data = await res.json();
-    const ip = typeof data?.ip === "string" ? data.ip : "";
+    const ip = await getClientIp();
     if (!ip) return;
 
     ipAttached = true;
     (window as any).__logrocketClientIp = ip;
 
-    if (currentLogRocketUserId) {
-      LogRocket.identify(currentLogRocketUserId, {
-        ip_address: ip,
-      });
+    if (window.__LOGROCKET_TEST_MODE) {
+      recordLogRocketTestEvent("client_ip", { ip });
+      return;
     }
 
-    LogRocket.track("client_ip", {
-      ip,
-      at: new Date().toISOString(),
-    });
-  } catch (_err) {
-    // no-op for local/dev telemetry setup
+    if (currentLogRocketUserId) {
+      LogRocket.identify(currentLogRocketUserId, { ip_address: ip });
+    }
+    LogRocket.track("client_ip", { ip, at: new Date().toISOString() });
+  } catch {
+    // telemetry is non-critical
   }
 }

--- a/src/client/src/lib/queryClient.ts
+++ b/src/client/src/lib/queryClient.ts
@@ -18,7 +18,7 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const baseHeaders = data ? { "Content-Type": "application/json" } : {};
+  const baseHeaders: Record<string, string> = data ? { "Content-Type": "application/json" } : {};
   const headers = await buildHeaders(baseHeaders);
 
   const res = await fetch(url, {

--- a/src/client/src/lib/queryClient.ts
+++ b/src/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { getClientIp } from "./tracking";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -7,14 +8,22 @@ async function throwIfResNotOk(res: Response) {
   }
 }
 
+async function buildHeaders(base: Record<string, string> = {}): Promise<Record<string, string>> {
+  const ip = await getClientIp();
+  return ip ? { ...base, "X-Client-IP": ip } : base;
+}
+
 export async function apiRequest(
   method: string,
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
+  const baseHeaders = data ? { "Content-Type": "application/json" } : {};
+  const headers = await buildHeaders(baseHeaders);
+
   const res = await fetch(url, {
     method,
-    headers: data ? { "Content-Type": "application/json" } : {},
+    headers,
     body: data ? JSON.stringify(data) : undefined,
     credentials: "include",
   });

--- a/src/client/src/lib/tracking.ts
+++ b/src/client/src/lib/tracking.ts
@@ -1,0 +1,81 @@
+import { isTrackingAllowed, getStoredConsent } from "./consent";
+
+export const TRACKER_COOKIE_NAME = "tr_uuid";
+
+export function getCookieValue(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|;\\s*)${name}=([^;]*)`)
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Returns the tracker UUID only when consent has been given.
+ * localStorage is checked first as a hard break condition.
+ */
+export function getTrackerUuid(): string | null {
+  const consent = getStoredConsent();
+  if (!consent) return null;
+  if (!isTrackingAllowed()) return null;
+  return getCookieValue(TRACKER_COOKIE_NAME);
+}
+
+let _ipCache: string | null = null;
+let _ipPromise: Promise<string | null> | null = null;
+
+export async function getClientIp(): Promise<string | null> {
+  if (_ipCache !== null) return _ipCache;
+  if (_ipPromise) return _ipPromise;
+
+  _ipPromise = fetch("/api/public/ip", { credentials: "include" })
+    .then((r) => r.json())
+    .then((d) => {
+      _ipCache = typeof d?.ip === "string" ? d.ip : null;
+      return _ipCache;
+    })
+    .catch(() => null);
+
+  return _ipPromise;
+}
+
+/**
+ * Notify the backend that this UUID has consented. Stores the UUID+IP
+ * association in browser_tracking / browser_tracking_ips.
+ * No-ops if tracking is not allowed.
+ */
+export async function initBrowserTracking(): Promise<void> {
+  if (!isTrackingAllowed()) return;
+
+  const uuid = getCookieValue(TRACKER_COOKIE_NAME);
+  if (!uuid) return;
+
+  const ip = await getClientIp();
+
+  fetch("/api/public/tracking/init", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(ip ? { "X-Client-IP": ip } : {}),
+    },
+    credentials: "include",
+    body: JSON.stringify({ ip }),
+  }).catch(() => {});
+}
+
+/**
+ * Store the tr_en query-param value in browser_tracking for consented users.
+ */
+export async function storeTrEn(value: string): Promise<void> {
+  if (!isTrackingAllowed()) return;
+
+  const uuid = getCookieValue(TRACKER_COOKIE_NAME);
+  if (!uuid) return;
+
+  fetch("/api/public/tracking/tr-en", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ trEn: value }),
+  }).catch(() => {});
+}

--- a/src/migrations/0006_browser_tracking.sql
+++ b/src/migrations/0006_browser_tracking.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS "browser_tracking" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "hashed_uuid" text NOT NULL UNIQUE,
+  "tr_en" text,
+  "consented_at" timestamp,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "browser_tracking_ips" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "hashed_uuid" text NOT NULL,
+  "ip" text NOT NULL,
+  "first_seen_at" timestamp DEFAULT now() NOT NULL,
+  "last_seen_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "browser_tracking_ips_uuid_ip_unique" UNIQUE("hashed_uuid", "ip")
+);
+
+CREATE INDEX IF NOT EXISTS "browser_tracking_ips_uuid_idx" ON "browser_tracking_ips"("hashed_uuid");
+
+CREATE TABLE IF NOT EXISTS "browser_request_logs" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "hashed_uuid" text NOT NULL,
+  "ip" text,
+  "method" text NOT NULL,
+  "path" text NOT NULL,
+  "status_code" integer,
+  "duration_ms" integer,
+  "meta" jsonb DEFAULT '{}' NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "browser_request_logs_uuid_idx" ON "browser_request_logs"("hashed_uuid");

--- a/src/migrations/0007_ip_rate_logs.sql
+++ b/src/migrations/0007_ip_rate_logs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "ip_rate_logs" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "ip" text NOT NULL,
+  "method" text NOT NULL,
+  "path" text NOT NULL,
+  "status_code" integer,
+  "tracking_ip_id" varchar REFERENCES browser_tracking_ips(id) ON DELETE SET NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "ip_rate_logs_ip_created_idx" ON "ip_rate_logs"("ip", "created_at");
+CREATE INDEX IF NOT EXISTS "ip_rate_logs_tracking_ip_id_idx" ON "ip_rate_logs"("tracking_ip_id");

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -331,6 +331,18 @@ export const browserRequestLogs = pgTable("browser_request_logs", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
+export const ipRateLogs = pgTable("ip_rate_logs", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  ip: text("ip").notNull(),
+  method: text("method").notNull(),
+  path: text("path").notNull(),
+  statusCode: integer("status_code"),
+  // NULL for opted-out users; set to browser_tracking_ips.id for consented users
+  trackingIpId: varchar("tracking_ip_id"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
 export type BrowserTracking = typeof browserTracking.$inferSelect;
 export type BrowserTrackingIp = typeof browserTrackingIps.$inferSelect;
 export type BrowserRequestLog = typeof browserRequestLogs.$inferSelect;
+export type IpRateLog = typeof ipRateLogs.$inferSelect;

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -295,3 +295,42 @@ export const legalDocumentVersions = pgTable(
 );
 
 export type DbLegalDocumentVersion = typeof legalDocumentVersions.$inferSelect;
+
+// ─── Browser Tracking ────────────────────────────────────────────────────────
+
+export const browserTracking = pgTable("browser_tracking", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  hashedUuid: text("hashed_uuid").notNull().unique(),
+  trEn: text("tr_en"),
+  consentedAt: timestamp("consented_at"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const browserTrackingIps = pgTable(
+  "browser_tracking_ips",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    hashedUuid: text("hashed_uuid").notNull(),
+    ip: text("ip").notNull(),
+    firstSeenAt: timestamp("first_seen_at").defaultNow().notNull(),
+    lastSeenAt: timestamp("last_seen_at").defaultNow().notNull(),
+  },
+  (t) => [uniqueIndex("browser_tracking_ips_uuid_ip_idx").on(t.hashedUuid, t.ip)],
+);
+
+export const browserRequestLogs = pgTable("browser_request_logs", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  hashedUuid: text("hashed_uuid").notNull(),
+  ip: text("ip"),
+  method: text("method").notNull(),
+  path: text("path").notNull(),
+  statusCode: integer("status_code"),
+  durationMs: integer("duration_ms"),
+  meta: jsonb("meta").default({}).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export type BrowserTracking = typeof browserTracking.$inferSelect;
+export type BrowserTrackingIp = typeof browserTrackingIps.$inferSelect;
+export type BrowserRequestLog = typeof browserRequestLogs.$inferSelect;

--- a/src/tests/backend-unit/tracking.test.ts
+++ b/src/tests/backend-unit/tracking.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateHashedUuid, getRequestTrackerUuid, TRACKER_COOKIE_NAME } from "../../backend/tracking-utils";
+
+// ── generateHashedUuid ────────────────────────────────────────────────────────
+
+test("generateHashedUuid returns a 64-char lowercase hex string", () => {
+  const uuid = generateHashedUuid();
+  assert.equal(typeof uuid, "string");
+  assert.equal(uuid.length, 64);
+  assert.match(uuid, /^[0-9a-f]{64}$/);
+});
+
+test("generateHashedUuid produces unique values each call", () => {
+  const a = generateHashedUuid();
+  const b = generateHashedUuid();
+  assert.notEqual(a, b);
+});
+
+// ── getRequestTrackerUuid ─────────────────────────────────────────────────────
+
+function fakeReq(cookieHeader?: string): { headers: { cookie?: string } } {
+  return { headers: { cookie: cookieHeader } };
+}
+
+test("getRequestTrackerUuid returns undefined when no cookie header", () => {
+  const req = fakeReq(undefined) as any;
+  assert.equal(getRequestTrackerUuid(req), undefined);
+});
+
+test("getRequestTrackerUuid returns undefined when cookie header has no tr_uuid", () => {
+  const req = fakeReq("session=abc123; other=val") as any;
+  assert.equal(getRequestTrackerUuid(req), undefined);
+});
+
+test("getRequestTrackerUuid parses tr_uuid from cookie header", () => {
+  const expected = "aabbccdd" + "0".repeat(56);
+  const req = fakeReq(`session=abc; ${TRACKER_COOKIE_NAME}=${expected}; foo=bar`) as any;
+  assert.equal(getRequestTrackerUuid(req), expected);
+});
+
+test("getRequestTrackerUuid parses tr_uuid when it is the only cookie", () => {
+  const expected = "deadbeef" + "1".repeat(56);
+  const req = fakeReq(`${TRACKER_COOKIE_NAME}=${expected}`) as any;
+  assert.equal(getRequestTrackerUuid(req), expected);
+});
+
+test("getRequestTrackerUuid handles URL-encoded cookie values", () => {
+  const value = "hello%20world";
+  const req = fakeReq(`${TRACKER_COOKIE_NAME}=${value}`) as any;
+  assert.equal(getRequestTrackerUuid(req), "hello world");
+});
+
+// ── TRACKER_COOKIE_NAME constant ──────────────────────────────────────────────
+
+test("TRACKER_COOKIE_NAME is tr_uuid", () => {
+  assert.equal(TRACKER_COOKIE_NAME, "tr_uuid");
+});

--- a/src/tests/backend-unit/tracking.test.ts
+++ b/src/tests/backend-unit/tracking.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { generateHashedUuid, getRequestTrackerUuid, TRACKER_COOKIE_NAME } from "../../backend/tracking-utils";
+import { generateHashedUuid, getRequestTrackerUuid, TRACKER_COOKIE_NAME, makeTrackingIpCacheKey } from "../../backend/tracking-utils";
 
 // ── generateHashedUuid ────────────────────────────────────────────────────────
 
@@ -55,4 +55,26 @@ test("getRequestTrackerUuid handles URL-encoded cookie values", () => {
 
 test("TRACKER_COOKIE_NAME is tr_uuid", () => {
   assert.equal(TRACKER_COOKIE_NAME, "tr_uuid");
+});
+
+// ── makeTrackingIpCacheKey ────────────────────────────────────────────────────
+
+test("makeTrackingIpCacheKey returns uuid::ip format", () => {
+  const key = makeTrackingIpCacheKey("abc123", "1.2.3.4");
+  assert.equal(key, "abc123::1.2.3.4");
+});
+
+test("makeTrackingIpCacheKey produces distinct keys for different uuid/ip combos", () => {
+  const a = makeTrackingIpCacheKey("uuid-A", "1.2.3.4");
+  const b = makeTrackingIpCacheKey("uuid-B", "1.2.3.4");
+  const c = makeTrackingIpCacheKey("uuid-A", "5.6.7.8");
+  assert.notEqual(a, b);
+  assert.notEqual(a, c);
+  assert.notEqual(b, c);
+});
+
+test("makeTrackingIpCacheKey does not collide when uuid and ip are swapped", () => {
+  const forward = makeTrackingIpCacheKey("aaa", "bbb");
+  const reversed = makeTrackingIpCacheKey("bbb", "aaa");
+  assert.notEqual(forward, reversed);
 });

--- a/src/tests/support/mock-api.ts
+++ b/src/tests/support/mock-api.ts
@@ -40,6 +40,12 @@ export async function installMockApi(page: Page) {
   await page.route("**/api/public/ip", (route) =>
     fulfillJson(route, { ip: "127.0.0.1" }),
   );
+  await page.route("**/api/public/tracking/init", (route) =>
+    fulfillJson(route, { ok: true }),
+  );
+  await page.route("**/api/public/tracking/tr-en", (route) =>
+    fulfillJson(route, { ok: true }),
+  );
 
   await page.route("**/api/legal/privacy", (route) => fulfillJson(route, legalDocFixture));
   await page.route("**/api/legal/terms", (route) => fulfillJson(route, legalDocFixture));
@@ -110,22 +116,26 @@ export async function installMockApi(page: Page) {
   );
 }
 
+export const TEST_TRACKER_UUID = "aabbccdd1122334455667788aabbccdd1122334455667788aabbccdd11223344";
+
 export async function seedBrowserState(
   page: Page,
   options: {
     introSeen?: boolean;
     consent?: "accept_all" | "reject_all" | "none";
     logRocketTestMode?: boolean;
+    trackerUuid?: string | false;
   } = {},
 ) {
   const {
     introSeen = true,
     consent = "reject_all",
     logRocketTestMode = true,
+    trackerUuid = TEST_TRACKER_UUID,
   } = options;
 
   await page.addInitScript(
-    ({ introSeen: shouldSeedIntro, consentChoice, testMode }) => {
+    ({ introSeen: shouldSeedIntro, consentChoice, testMode, uuid }) => {
       Math.random = () => 0.42;
 
       if (testMode) {
@@ -137,6 +147,10 @@ export async function seedBrowserState(
         window.localStorage.setItem("__root_intro_seen_until", String(Date.now() + 3 * 24 * 60 * 60 * 1000));
       } else {
         window.localStorage.removeItem("__root_intro_seen_until");
+      }
+
+      if (uuid) {
+        document.cookie = `tr_uuid=${uuid}; path=/; max-age=315360000`;
       }
 
       if (consentChoice === "none") {
@@ -161,6 +175,7 @@ export async function seedBrowserState(
       introSeen,
       consentChoice: consent,
       testMode: logRocketTestMode,
+      uuid: trackerUuid || "",
     },
   );
 }

--- a/src/tests/ui-test/tracking.spec.ts
+++ b/src/tests/ui-test/tracking.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "@playwright/test";
+import { installMockApi, seedBrowserState, TEST_TRACKER_UUID } from "../support/mock-api";
+
+async function setup(
+  page: import("@playwright/test").Page,
+  consent: "accept_all" | "reject_all" | "none" = "none",
+  opts: { trackerUuid?: string | false } = {},
+) {
+  await installMockApi(page);
+  await seedBrowserState(page, {
+    introSeen: true,
+    consent,
+    logRocketTestMode: true,
+    ...opts,
+  });
+}
+
+function logRocketEvents(page: import("@playwright/test").Page) {
+  return page.evaluate(() => window.__LOGROCKET_TEST_EVENTS ?? []);
+}
+
+// ── UUID cookie ───────────────────────────────────────────────────────────────
+
+test("tr_uuid cookie is readable from JS after being set", async ({ page }) => {
+  await setup(page, "accept_all");
+  await page.goto("/");
+  const uuid = await page.evaluate(() =>
+    document.cookie.split(";").find((c) => c.trim().startsWith("tr_uuid="))?.split("=")[1] ?? null,
+  );
+  expect(uuid).toBe(TEST_TRACKER_UUID);
+});
+
+// ── Consent break condition ───────────────────────────────────────────────────
+
+test("getTrackerUuid returns null when localStorage has no consent record", async ({ page }) => {
+  await setup(page, "none");
+  await page.goto("/");
+  const result = await page.evaluate(() => {
+    const { getTrackerUuid } = (window as any).__trackingLib ?? {};
+    return typeof getTrackerUuid === "function" ? getTrackerUuid() : "NO_LIB";
+  });
+  // Without the lib exposed we verify indirectly: user_uuid must NOT be emitted
+  const events = await logRocketEvents(page);
+  expect(events.some((e) => e.event === "user_uuid")).toBe(false);
+});
+
+test("user_uuid LogRocket event is NOT emitted without consent", async ({ page }) => {
+  await setup(page, "none");
+  await page.goto("/");
+  await page.waitForTimeout(300);
+  const events = await logRocketEvents(page);
+  expect(events.some((e) => e.event === "user_uuid")).toBe(false);
+});
+
+test("user_uuid LogRocket event IS emitted after Accept All", async ({ page }) => {
+  await setup(page, "none");
+  await page.goto("/");
+  await page.getByRole("button", { name: "Accept All" }).click();
+
+  await expect
+    .poll(async () => {
+      const events = await logRocketEvents(page);
+      return events.some((e) => e.event === "user_uuid");
+    })
+    .toBe(true);
+
+  const events = await logRocketEvents(page);
+  const uuidEvent = events.find((e) => e.event === "user_uuid");
+  expect(uuidEvent?.payload?.uuid).toBe(TEST_TRACKER_UUID);
+});
+
+test("user_uuid LogRocket event IS emitted when page loads with pre-existing consent", async ({ page }) => {
+  await setup(page, "accept_all");
+  await page.goto("/");
+
+  await expect
+    .poll(async () => {
+      const events = await logRocketEvents(page);
+      return events.some((e) => e.event === "user_uuid");
+    })
+    .toBe(true);
+});
+
+// ── Route tracking (no query params logged) ───────────────────────────────────
+
+test("route_change event does not include query params or rawQuery fields", async ({ page }) => {
+  await setup(page, "accept_all");
+  await page.goto("/?utm_source=test&ref=abc");
+
+  await page.waitForTimeout(300);
+  const events = await logRocketEvents(page);
+  const routeChanges = events.filter((e) => e.event === "route_change");
+  expect(routeChanges.length).toBeGreaterThan(0);
+  for (const ev of routeChanges) {
+    expect(ev.payload).not.toHaveProperty("query");
+    expect(ev.payload).not.toHaveProperty("rawQuery");
+  }
+});
+
+test("query_params event is never emitted", async ({ page }) => {
+  await setup(page, "accept_all");
+  await page.goto("/?utm_source=test");
+  await page.waitForTimeout(300);
+  const events = await logRocketEvents(page);
+  expect(events.some((e) => e.event === "query_params")).toBe(false);
+});
+
+// ── tr_en query param ─────────────────────────────────────────────────────────
+
+test("tr_en param is stripped from URL after page load (no consent)", async ({ page }) => {
+  const trackingRequests: string[] = [];
+  await installMockApi(page);
+  await page.route("**/api/public/tracking/tr-en", (route) => {
+    trackingRequests.push("called");
+    return route.fulfill({ status: 200, contentType: "application/json", body: '{"ok":true}' });
+  });
+  await seedBrowserState(page, { introSeen: true, consent: "none", logRocketTestMode: true });
+  await page.goto("/?tr_en=campaign1");
+
+  // Wait for the redirect to settle
+  await page.waitForURL((url) => !url.searchParams.has("tr_en"), { timeout: 5000 });
+  expect(page.url()).not.toContain("tr_en");
+  expect(trackingRequests).toHaveLength(0);
+});
+
+test("tr_en param is stripped and backend is called when user has consented", async ({ page }) => {
+  const trackingRequests: string[] = [];
+  await installMockApi(page);
+  await page.route("**/api/public/tracking/tr-en", async (route) => {
+    const body = await route.request().postDataJSON();
+    trackingRequests.push(body.trEn);
+    await route.fulfill({ status: 200, contentType: "application/json", body: '{"ok":true}' });
+  });
+  await seedBrowserState(page, { introSeen: true, consent: "accept_all", logRocketTestMode: true });
+  await page.goto("/?tr_en=partner42");
+
+  await page.waitForURL((url) => !url.searchParams.has("tr_en"), { timeout: 5000 });
+  expect(page.url()).not.toContain("tr_en");
+  await expect.poll(() => trackingRequests).toEqual(["partner42"]);
+});
+
+test("tr_en strips other params while preserving them", async ({ page }) => {
+  await installMockApi(page);
+  await seedBrowserState(page, { introSeen: true, consent: "none", logRocketTestMode: true });
+  await page.goto("/?keep=yes&tr_en=x");
+
+  await page.waitForURL((url) => !url.searchParams.has("tr_en"), { timeout: 5000 });
+  const url = new URL(page.url());
+  expect(url.searchParams.has("tr_en")).toBe(false);
+  expect(url.searchParams.get("keep")).toBe("yes");
+});
+
+// ── tracking/init called after consent ───────────────────────────────────────
+
+test("tracking init endpoint is called after Accept All", async ({ page }) => {
+  const initCalls: number[] = [];
+  await installMockApi(page);
+  await page.route("**/api/public/tracking/init", (route) => {
+    initCalls.push(1);
+    return route.fulfill({ status: 200, contentType: "application/json", body: '{"ok":true}' });
+  });
+  await seedBrowserState(page, { introSeen: true, consent: "none", logRocketTestMode: true });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Accept All" }).click();
+
+  await expect.poll(() => initCalls.length).toBeGreaterThan(0);
+});
+
+test("tracking init endpoint is NOT called when consent is rejected", async ({ page }) => {
+  const initCalls: number[] = [];
+  await installMockApi(page);
+  await page.route("**/api/public/tracking/init", (route) => {
+    initCalls.push(1);
+    return route.fulfill({ status: 200, contentType: "application/json", body: '{"ok":true}' });
+  });
+  await seedBrowserState(page, { introSeen: true, consent: "none", logRocketTestMode: true });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Reject All" }).click();
+  await page.waitForTimeout(500);
+  expect(initCalls).toHaveLength(0);
+});


### PR DESCRIPTION
…based system

- Removes arbitrary query-param forwarding to LogRocket (query_params event, rawQuery)
- Backend middleware generates a hashed SHA-256 UUID cookie (tr_uuid, never-expires, JS-readable) on every request so all clients get a persistent anonymous identity
- New browser_tracking, browser_tracking_ips, and browser_request_logs tables with migration 0006_browser_tracking.sql; IP is tracked per UUID (many devices → one UUID)
- POST /api/public/tracking/init upserts UUID + IP after consent; /tracking/tr-en upserts the tr_en query-param value for consented users
- TrackingBridge component in App calls initBrowserTracking on consent-granted; all tracking is consent-gated via localStorage break condition before cookie access
- TrEnProcessor (router-level) strips tr_en= from any page URL and reloads; stores value only when analytics consent exists
- LogRocket now emits user_uuid custom event with hashed UUID instead of raw query params
- queryClient.ts apiRequest wrapper auto-includes X-Client-IP header (cached via getClientIp)
- ProjectChat forwards trackerUuid in chat POST body; backend adds it to LangSmith run metadata
- 8 passing backend unit tests (tracking-utils) and 12 new Playwright UI tests for the full flow

https://claude.ai/code/session_01Mb8b4mfuaqPW5hn9W7j6ct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser tracking with a persistent per-browser identifier, consent-gated analytics, client IP capture for security/rate logging, and endpoints to initialize tracking and submit campaign data.
  * Client updates to emit tracking events, strip certain query params, and integrate with telemetry only when consented.

* **Tests**
  * Added unit and UI tests covering tracking helpers, consent gating, route payloads, and tracking endpoints.

* **Documentation**
  * Updated privacy and tracking notices to reflect new identifier, consent behavior, and data handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matt2jog/portfolio/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->