### PR TITLE
feat(personalization): add admin welcome messages and personalized intro animation

### DIFF
--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -4,6 +4,7 @@ import { createHash } from "crypto";
 import { authRoutes, requireAdmin, requireAuth } from "./auth";
 import { db } from "./data/db";
 import { getRequestTrackerUuid, registerTrackedUuid, upsertTrEn } from "./tracking";
+import { isValidWelcomeSlug } from "./welcome-message-utils";
 import { detectCountryFromIP, extractClientIp } from "./geoip";
 import { loadLegalDoc } from "./markdown";
 import { getGithubActivity, getGithubTimeline } from "./github";
@@ -33,9 +34,12 @@ import {
   insertExperienceSchema,
   updateExperienceSchema,
   aiModels,
+  welcomeMessages,
+  insertWelcomeMessageSchema,
+  updateWelcomeMessageSchema,
 } from "@shared/schema";
 import { adminPolicyAcceptance } from "@shared/schema_policy";
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { Agent, GradientProvider, FireworksProvider, FallbackProvider } from "./agent";
 import type { LLMProvider } from "./agent";
 import { ensureRenderableMermaid } from "./agent/mermaid";
@@ -1507,6 +1511,120 @@ export async function registerRoutes(
     invalidateProjectsCache();
     await logAudit(req, "project.restore", { id: projectId });
     res.json(restored);
+  });
+
+  // ========== WELCOME MESSAGES (PERSONALIZATION) ==========
+
+  // Public: look up a welcome message by slug (archived messages are still active)
+  app.get("/api/public/welcome-message", async (req, res) => {
+    const slug = req.query.welcome;
+    if (!isValidWelcomeSlug(slug)) {
+      return res.status(400).json({ error: "Invalid or missing welcome slug" });
+    }
+
+    const [row] = await db
+      .select({ message: welcomeMessages.message })
+      .from(welcomeMessages)
+      .where(eq(welcomeMessages.slug, slug))
+      .limit(1);
+
+    if (!row) return res.status(404).json({ error: "Welcome message not found" });
+    res.json({ message: row.message });
+  });
+
+  // Admin: list active (non-archived) welcome messages
+  app.get("/api/admin/welcome-messages", requireAdmin, async (_req, res) => {
+    const rows = await db
+      .select()
+      .from(welcomeMessages)
+      .where(isNull(welcomeMessages.archivedAt))
+      .orderBy(desc(welcomeMessages.createdAt));
+    res.json(rows);
+  });
+
+  // Admin: list archived welcome messages
+  app.get("/api/admin/welcome-messages/archived", requireAdmin, async (_req, res) => {
+    const rows = await db
+      .select()
+      .from(welcomeMessages)
+      .where(isNotNull(welcomeMessages.archivedAt))
+      .orderBy(desc(welcomeMessages.archivedAt));
+    res.json(rows);
+  });
+
+  // Admin: create welcome message
+  app.post("/api/admin/welcome-messages", requireAdmin, async (req, res) => {
+    const parsed = insertWelcomeMessageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid payload", details: parsed.error.flatten() });
+    }
+    if (!isValidWelcomeSlug(parsed.data.slug)) {
+      return res.status(400).json({ error: "Slug must be lowercase alphanumeric with hyphens (no leading/trailing hyphens), max 63 chars" });
+    }
+    const [row] = await db
+      .insert(welcomeMessages)
+      .values(parsed.data)
+      .returning();
+    await logAudit(req, "welcome_message.create", { id: row.id, slug: row.slug });
+    res.status(201).json(row);
+  });
+
+  // Admin: update welcome message
+  app.put("/api/admin/welcome-messages/:id", requireAdmin, async (req, res) => {
+    const id = routeId(req.params.id);
+    const parsed = updateWelcomeMessageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid payload", details: parsed.error.flatten() });
+    }
+    if (parsed.data.slug !== undefined && !isValidWelcomeSlug(parsed.data.slug)) {
+      return res.status(400).json({ error: "Slug must be lowercase alphanumeric with hyphens (no leading/trailing hyphens), max 63 chars" });
+    }
+    const [row] = await db
+      .update(welcomeMessages)
+      .set({ ...parsed.data, updatedAt: new Date() })
+      .where(eq(welcomeMessages.id, id))
+      .returning();
+    if (!row) return res.status(404).json({ error: "Welcome message not found" });
+    await logAudit(req, "welcome_message.update", { id, changes: parsed.data });
+    res.json(row);
+  });
+
+  // Admin: archive welcome message (hides from admin list, stays active for URL lookup)
+  app.post("/api/admin/welcome-messages/:id/archive", requireAdmin, async (req, res) => {
+    const id = routeId(req.params.id);
+    const [row] = await db
+      .update(welcomeMessages)
+      .set({ archivedAt: new Date(), updatedAt: new Date() })
+      .where(and(eq(welcomeMessages.id, id), isNull(welcomeMessages.archivedAt)))
+      .returning();
+    if (!row) return res.status(404).json({ error: "Welcome message not found or already archived" });
+    await logAudit(req, "welcome_message.archive", { id });
+    res.json(row);
+  });
+
+  // Admin: unarchive welcome message
+  app.post("/api/admin/welcome-messages/:id/unarchive", requireAdmin, async (req, res) => {
+    const id = routeId(req.params.id);
+    const [row] = await db
+      .update(welcomeMessages)
+      .set({ archivedAt: null, updatedAt: new Date() })
+      .where(and(eq(welcomeMessages.id, id), isNotNull(welcomeMessages.archivedAt)))
+      .returning();
+    if (!row) return res.status(404).json({ error: "Welcome message not found or not archived" });
+    await logAudit(req, "welcome_message.unarchive", { id });
+    res.json(row);
+  });
+
+  // Admin: hard delete welcome message
+  app.delete("/api/admin/welcome-messages/:id", requireAdmin, async (req, res) => {
+    const id = routeId(req.params.id);
+    const [deleted] = await db
+      .delete(welcomeMessages)
+      .where(eq(welcomeMessages.id, id))
+      .returning();
+    if (!deleted) return res.status(404).json({ error: "Welcome message not found" });
+    await logAudit(req, "welcome_message.delete", { id, slug: deleted.slug });
+    res.json({ ok: true });
   });
 
   return httpServer;

--- a/src/backend/welcome-message-utils.ts
+++ b/src/backend/welcome-message-utils.ts
@@ -1,0 +1,10 @@
+export const WELCOME_SLUG_MAX_LENGTH = 63;
+
+// slug must be lowercase alphanumeric with single hyphens between segments, no leading/trailing hyphens
+const SLUG_RE = /^[a-z0-9](-?[a-z0-9])*$/;
+
+export function isValidWelcomeSlug(slug: unknown): slug is string {
+  if (typeof slug !== "string") return false;
+  if (slug.length < 1 || slug.length > WELCOME_SLUG_MAX_LENGTH) return false;
+  return SLUG_RE.test(slug);
+}

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -8,7 +8,12 @@ import { getQueryFn } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ConsentBanner } from "@/components/ConsentBanner";
-import { FirstVisitIntro, shouldShowFirstVisitIntro } from "@/components/FirstVisitIntro";
+import {
+  FirstVisitIntro,
+  shouldShowFirstVisitIntro,
+  INTRO_FORCE_SHOW_KEY,
+  INTRO_WELCOME_SLUG_KEY,
+} from "@/components/FirstVisitIntro";
 import { getStoredConsent, isGlobalOptOutEnabled } from "@/lib/consent";
 import { detectJurisdiction } from "@/lib/geoip";
 import NotFound from "@/pages/not-found";
@@ -113,6 +118,31 @@ function TrEnProcessor() {
   return null;
 }
 
+// Detects ?welcome=<slug>, stores the slug and a force-show flag in localStorage,
+// then strips the param and reloads so the intro plays even if the TTL is active.
+function WelcomeProcessor() {
+  const [location] = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const welcomeSlug = params.get("welcome");
+    if (!welcomeSlug) return;
+
+    params.delete("welcome");
+    const newSearch = params.toString();
+    const cleanUrl =
+      window.location.pathname +
+      (newSearch ? `?${newSearch}` : "") +
+      window.location.hash;
+
+    window.localStorage.setItem(INTRO_WELCOME_SLUG_KEY, welcomeSlug);
+    window.localStorage.setItem(INTRO_FORCE_SHOW_KEY, "1");
+    window.location.replace(cleanUrl);
+  }, [location]);
+
+  return null;
+}
+
 function ConsentManager({ disabled = false }: { disabled?: boolean }) {
   const [showBanner, setShowBanner] = useState(false);
   const [jurisdiction, setJurisdiction] = useState<string | null>(null);
@@ -178,6 +208,7 @@ function Router() {
 function App() {
   const [location] = useLocation();
   const [showIntro, setShowIntro] = useState(() => location === "/" && shouldShowFirstVisitIntro());
+  const [welcomeMessage, setWelcomeMessage] = useState<string | null>(null);
   const consentDisabled = showIntro && location === "/";
 
   useEffect(() => {
@@ -188,17 +219,36 @@ function App() {
     }
   }, [location]);
 
+  // Fetch the personalized welcome message for the intro animation, if a slug is stored.
+  useEffect(() => {
+    const slug = typeof window !== "undefined"
+      ? window.localStorage.getItem(INTRO_WELCOME_SLUG_KEY)
+      : null;
+    if (!slug) return;
+
+    fetch(`/api/public/welcome-message?welcome=${encodeURIComponent(slug)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.message) setWelcomeMessage(data.message);
+      })
+      .catch(() => {});
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <TrEnProcessor />
+        <WelcomeProcessor />
         <ConsentManager disabled={consentDisabled} />
         <LogRocketBridge />
         <TrackingBridge />
         <Toaster />
         <Router />
         {showIntro && location === "/" && (
-          <FirstVisitIntro onComplete={() => setShowIntro(false)} />
+          <FirstVisitIntro
+            onComplete={() => setShowIntro(false)}
+            welcomeMessage={welcomeMessage}
+          />
         )}
       </TooltipProvider>
     </QueryClientProvider>

--- a/src/client/src/components/FirstVisitIntro.tsx
+++ b/src/client/src/components/FirstVisitIntro.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Speech } from "lucide-react";
 import { IntroDither } from "./IntroDither";
 
 export const INTRO_STORAGE_KEY = "__root_intro_seen_until";
 export const INTRO_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+export const INTRO_FORCE_SHOW_KEY = "__intro_force_show";
+export const INTRO_WELCOME_SLUG_KEY = "__intro_welcome_slug";
 
-type IntroStage = "phrase" | "gap" | "name";
+type IntroStage = "phrase" | "gap" | "welcome" | "name";
 type TypingPhase =
   | "introPause"
   | "intro"
@@ -15,7 +17,10 @@ type TypingPhase =
   | "promptPause"
   | "prompt"
   | "buttonPause"
-  | "button";
+  | "button"
+  | "welcomePause"
+  | "welcomeTyping"
+  | "welcomeDone";
 
 function getTimePhrase() {
   const hour = new Date().getHours();
@@ -33,17 +38,20 @@ function getTimePhrase() {
 
 export function shouldShowFirstVisitIntro() {
   if (typeof window === "undefined") return false;
-
+  if (window.localStorage.getItem(INTRO_FORCE_SHOW_KEY) === "1") return true;
   const expiresAt = Number(window.localStorage.getItem(INTRO_STORAGE_KEY));
   return !Number.isFinite(expiresAt) || expiresAt <= Date.now();
 }
 
 function storeIntroVisit() {
   window.localStorage.setItem(INTRO_STORAGE_KEY, String(Date.now() + INTRO_TTL_MS));
+  window.localStorage.removeItem(INTRO_FORCE_SHOW_KEY);
+  window.localStorage.removeItem(INTRO_WELCOME_SLUG_KEY);
 }
 
 interface FirstVisitIntroProps {
   onComplete: () => void;
+  welcomeMessage?: string | null;
 }
 
 const INTRO_TEXT = "My name is";
@@ -62,20 +70,31 @@ declare global {
       typedIntro?: string;
       typedName?: string;
       typedPrompt?: string;
+      welcomeMessage?: string;
+      typedWelcomeText?: string;
     };
   }
 }
 
-export function FirstVisitIntro({ onComplete }: FirstVisitIntroProps) {
+export function FirstVisitIntro({ onComplete, welcomeMessage }: FirstVisitIntroProps) {
   const testState =
     typeof window !== "undefined" ? window.__FIRST_VISIT_INTRO_TEST_STATE : undefined;
+
+  // Allow test state to inject a welcome message
+  const effectiveWelcome = testState?.welcomeMessage ?? welcomeMessage ?? null;
+
   const phrase = useMemo(() => testState?.phrase ?? getTimePhrase(), [testState?.phrase]);
   const [stage, setStage] = useState<IntroStage>(testState?.stage ?? "phrase");
   const [showPrompt, setShowPrompt] = useState(testState?.showPrompt ?? false);
   const [typedIntro, setTypedIntro] = useState(testState?.typedIntro ?? "");
   const [typedName, setTypedName] = useState(testState?.typedName ?? "");
   const [typedPrompt, setTypedPrompt] = useState(testState?.typedPrompt ?? "");
+  const [typedWelcomeText, setTypedWelcomeText] = useState(testState?.typedWelcomeText ?? "");
   const [typingPhase, setTypingPhase] = useState<TypingPhase>(testState?.typingPhase ?? "introPause");
+
+  // Ref so gap-exit timer can read the latest welcome message without re-running
+  const effectiveWelcomeRef = useRef(effectiveWelcome);
+  effectiveWelcomeRef.current = effectiveWelcome;
 
   useEffect(() => {
     document.body.style.overflow = "hidden";
@@ -84,18 +103,77 @@ export function FirstVisitIntro({ onComplete }: FirstVisitIntroProps) {
     };
   }, []);
 
+  // phrase → gap at 4000ms (fixed, regardless of welcome)
   useEffect(() => {
     if (testState) return;
-
     const gapTimer = window.setTimeout(() => setStage("gap"), 4000);
-    const nameTimer = window.setTimeout(() => setStage("name"), 8000);
-
-    return () => {
-      window.clearTimeout(gapTimer);
-      window.clearTimeout(nameTimer);
-    };
+    return () => window.clearTimeout(gapTimer);
   }, [testState]);
 
+  // gap → welcome (if message) or name (no message), always 4000ms gap
+  useEffect(() => {
+    if (testState) return;
+    if (stage !== "gap") return;
+
+    const timer = window.setTimeout(() => {
+      if (effectiveWelcomeRef.current) {
+        setStage("welcome");
+      } else {
+        setStage("name");
+      }
+    }, 4000);
+    return () => window.clearTimeout(timer);
+  }, [testState, stage]);
+
+  // welcome stage init
+  useEffect(() => {
+    if (testState) return;
+    if (stage !== "welcome") return;
+
+    setTypedWelcomeText("");
+    setTypingPhase("welcomePause");
+
+    const timer = window.setTimeout(() => setTypingPhase("welcomeTyping"), SECTION_PAUSE_MS);
+    return () => window.clearTimeout(timer);
+  }, [stage, testState]);
+
+  // welcome typing: char-by-char, extra pause on newlines
+  useEffect(() => {
+    if (testState) return;
+    if (typingPhase !== "welcomeTyping") return;
+    if (!effectiveWelcome) return;
+
+    let timeoutId: ReturnType<typeof window.setTimeout>;
+    let index = 0;
+
+    function typeNext() {
+      index += 1;
+      setTypedWelcomeText(effectiveWelcome!.slice(0, index));
+
+      if (index >= effectiveWelcome!.length) {
+        timeoutId = window.setTimeout(() => setTypingPhase("welcomeDone"), SECTION_PAUSE_MS);
+        return;
+      }
+
+      const lastTyped = effectiveWelcome![index - 1];
+      const delay = lastTyped === "\n" ? SECTION_PAUSE_MS : TYPE_DELAY_MS;
+      timeoutId = window.setTimeout(typeNext, delay);
+    }
+
+    timeoutId = window.setTimeout(typeNext, TYPE_DELAY_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [testState, typingPhase, effectiveWelcome]);
+
+  // welcome done → name
+  useEffect(() => {
+    if (testState) return;
+    if (typingPhase !== "welcomeDone") return;
+
+    const timer = window.setTimeout(() => setStage("name"), SECTION_PAUSE_MS * 2);
+    return () => window.clearTimeout(timer);
+  }, [testState, typingPhase]);
+
+  // name stage init
   useEffect(() => {
     if (testState) return;
     if (stage !== "name") return;
@@ -193,13 +271,13 @@ export function FirstVisitIntro({ onComplete }: FirstVisitIntroProps) {
     if (!("speechSynthesis" in window)) return;
 
     window.speechSynthesis.cancel();
-    
+
     // Different TTS engines process phonetic spellings differently.
     // "zs" works perfectly for the Windows TTS engine but often breaks on others.
     // "zh" is a much more universally understood phonetic for Apple, Android, and Linux engines.
-    const isWindows = typeof navigator !== "undefined" && 
+    const isWindows = typeof navigator !== "undefined" &&
       (/Win/.test(navigator.platform) || /Windows/.test(navigator.userAgent));
-    
+
     const phoneticName = isWindows ? "Matthew too zsaawg" : "Matthew too zhawg";
 
     const utterance = new SpeechSynthesisUtterance(phoneticName);
@@ -218,6 +296,10 @@ export function FirstVisitIntro({ onComplete }: FirstVisitIntroProps) {
   const showPromptCursor = typingPhase === "promptPause" || typingPhase === "prompt";
   const showButtonCursor = typingPhase === "buttonPause";
   const showPhonetic = !["introPause", "intro", "namePause", "name"].includes(typingPhase);
+  const showWelcomeCursor = typingPhase === "welcomePause" || typingPhase === "welcomeTyping";
+
+  // Split typed welcome text into lines for rendering
+  const welcomeDisplayLines = typedWelcomeText.split("\n");
 
   return (
     <div
@@ -254,6 +336,27 @@ export function FirstVisitIntro({ onComplete }: FirstVisitIntroProps) {
             >
               {phrase}
             </motion.h1>
+          ) : stage === "welcome" ? (
+            <motion.div
+              key="welcome"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.8, ease: "easeOut" }}
+              className="flex max-w-3xl flex-col items-center gap-1"
+            >
+              {welcomeDisplayLines.map((line, i, arr) => (
+                <p
+                  key={i}
+                  className="text-balance text-3xl font-black leading-tight tracking-normal text-white sm:text-5xl"
+                >
+                  {line || " "}
+                  {i === arr.length - 1 && showWelcomeCursor && (
+                    <span className="ml-1 inline-block h-[0.9em] w-[0.08em] translate-y-[0.1em] animate-pulse bg-cyan-200" />
+                  )}
+                </p>
+              ))}
+            </motion.div>
           ) : stage === "name" ? (
             <motion.div
               key="name"

--- a/src/client/src/components/FirstVisitIntro.tsx
+++ b/src/client/src/components/FirstVisitIntro.tsx
@@ -143,25 +143,29 @@ export function FirstVisitIntro({ onComplete, welcomeMessage }: FirstVisitIntroP
     if (typingPhase !== "welcomeTyping") return;
     if (!effectiveWelcome) return;
 
-    let timeoutId: ReturnType<typeof window.setTimeout>;
+    let cancelled = false;
     let index = 0;
 
-    function typeNext() {
-      index += 1;
-      setTypedWelcomeText(effectiveWelcome!.slice(0, index));
+    function scheduleNext(delay: number) {
+      window.setTimeout(() => {
+        if (cancelled) return;
+        index += 1;
+        setTypedWelcomeText(effectiveWelcome!.slice(0, index));
 
-      if (index >= effectiveWelcome!.length) {
-        timeoutId = window.setTimeout(() => setTypingPhase("welcomeDone"), SECTION_PAUSE_MS);
-        return;
-      }
+        if (index >= effectiveWelcome!.length) {
+          window.setTimeout(() => {
+            if (!cancelled) setTypingPhase("welcomeDone");
+          }, SECTION_PAUSE_MS);
+          return;
+        }
 
-      const lastTyped = effectiveWelcome![index - 1];
-      const delay = lastTyped === "\n" ? SECTION_PAUSE_MS : TYPE_DELAY_MS;
-      timeoutId = window.setTimeout(typeNext, delay);
+        const lastTyped = effectiveWelcome![index - 1];
+        scheduleNext(lastTyped === "\n" ? SECTION_PAUSE_MS : TYPE_DELAY_MS);
+      }, delay);
     }
 
-    timeoutId = window.setTimeout(typeNext, TYPE_DELAY_MS);
-    return () => window.clearTimeout(timeoutId);
+    scheduleNext(TYPE_DELAY_MS);
+    return () => { cancelled = true; };
   }, [testState, typingPhase, effectiveWelcome]);
 
   // welcome done → name

--- a/src/client/src/components/admin/AdminPersonalizationPanel.tsx
+++ b/src/client/src/components/admin/AdminPersonalizationPanel.tsx
@@ -1,0 +1,388 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { toast } from "@/hooks/use-toast";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+interface WelcomeMessage {
+  id: string;
+  slug: string;
+  label: string;
+  message: string;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MessageForm {
+  id?: string;
+  slug: string;
+  label: string;
+  message: string;
+}
+
+const blankForm: MessageForm = { slug: "", label: "", message: "" };
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return "Unknown error";
+}
+
+function getBaseUrl(): string {
+  return typeof window !== "undefined" ? window.location.origin : "https://2jog.dev";
+}
+
+export default function AdminPersonalizationPanel() {
+  const [form, setForm] = useState<MessageForm>(blankForm);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<WelcomeMessage | null>(null);
+  const [showArchived, setShowArchived] = useState(false);
+
+  const activeQuery = useQuery<WelcomeMessage[]>({
+    queryKey: ["/api/admin/welcome-messages"],
+  });
+
+  const archivedQuery = useQuery<WelcomeMessage[]>({
+    queryKey: ["/api/admin/welcome-messages/archived"],
+    enabled: showArchived,
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (form.id) {
+        await apiRequest("PUT", `/api/admin/welcome-messages/${form.id}`, {
+          slug: form.slug,
+          label: form.label,
+          message: form.message,
+        });
+      } else {
+        await apiRequest("POST", "/api/admin/welcome-messages", {
+          slug: form.slug,
+          label: form.label,
+          message: form.message,
+        });
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/welcome-messages"] });
+      setForm(blankForm);
+      setDialogOpen(false);
+      toast({ title: "Saved", description: form.id ? "Welcome message updated" : "Welcome message created" });
+    },
+    onError: (error) => {
+      toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await apiRequest("DELETE", `/api/admin/welcome-messages/${id}`, undefined);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/welcome-messages"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/welcome-messages/archived"] });
+      setDeleteTarget(null);
+      toast({ title: "Deleted", description: "Welcome message permanently deleted" });
+    },
+    onError: (error) => {
+      toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
+    },
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await apiRequest("POST", `/api/admin/welcome-messages/${id}/archive`, {});
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/welcome-messages"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/welcome-messages/archived"] });
+      toast({ title: "Archived", description: "Message hidden from this list but still active for its URL" });
+    },
+    onError: (error) => {
+      toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
+    },
+  });
+
+  const unarchiveMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await apiRequest("POST", `/api/admin/welcome-messages/${id}/unarchive`, {});
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/welcome-messages"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/welcome-messages/archived"] });
+      toast({ title: "Restored", description: "Welcome message is active again" });
+    },
+    onError: (error) => {
+      toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
+    },
+  });
+
+  function openEdit(msg: WelcomeMessage) {
+    setForm({ id: msg.id, slug: msg.slug, label: msg.label, message: msg.message });
+    setDialogOpen(true);
+  }
+
+  function openCreate() {
+    setForm(blankForm);
+    setDialogOpen(true);
+  }
+
+  function copyUrl(slug: string) {
+    const url = `${getBaseUrl()}/?welcome=${encodeURIComponent(slug)}`;
+    navigator.clipboard.writeText(url).then(() => {
+      toast({ title: "Copied", description: url });
+    });
+  }
+
+  const activeMessages = activeQuery.data ?? [];
+  const archivedMessages = archivedQuery.data ?? [];
+
+  return (
+    <div data-testid="admin-personalization-panel" className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold">Welcome Messages</h2>
+          <p className="text-sm text-white/50 mt-1">
+            Each message maps to a custom URL that triggers a personalized intro animation.
+          </p>
+        </div>
+        <button
+          data-testid="create-welcome-message"
+          onClick={openCreate}
+          className="px-4 py-2 border border-white/30 text-sm hover:border-white/60"
+        >
+          + New Message
+        </button>
+      </div>
+
+      {activeQuery.isLoading && (
+        <p className="text-white/50 text-sm">Loading…</p>
+      )}
+
+      {!activeQuery.isLoading && activeMessages.length === 0 && (
+        <p className="text-white/40 text-sm border border-white/10 p-4">
+          No welcome messages yet. Create one to generate a personalized URL.
+        </p>
+      )}
+
+      <div className="space-y-3">
+        {activeMessages.map((msg) => (
+          <MessageCard
+            key={msg.id}
+            msg={msg}
+            onEdit={() => openEdit(msg)}
+            onCopyUrl={() => copyUrl(msg.slug)}
+            onArchive={() => archiveMutation.mutate(msg.id)}
+            onDelete={() => setDeleteTarget(msg)}
+          />
+        ))}
+      </div>
+
+      {/* Archived section */}
+      <div className="border-t border-white/10 pt-6">
+        <button
+          onClick={() => setShowArchived((v) => !v)}
+          className="text-sm text-white/40 hover:text-white/70"
+        >
+          {showArchived ? "Hide archived" : "Show archived messages"}
+        </button>
+
+        {showArchived && (
+          <div className="mt-4 space-y-3">
+            {archivedQuery.isLoading && <p className="text-white/50 text-sm">Loading…</p>}
+            {!archivedQuery.isLoading && archivedMessages.length === 0 && (
+              <p className="text-white/40 text-sm">No archived messages.</p>
+            )}
+            {archivedMessages.map((msg) => (
+              <MessageCard
+                key={msg.id}
+                msg={msg}
+                archived
+                onEdit={() => openEdit(msg)}
+                onCopyUrl={() => copyUrl(msg.slug)}
+                onUnarchive={() => unarchiveMutation.mutate(msg.id)}
+                onDelete={() => setDeleteTarget(msg)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Create / Edit dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="bg-black border border-white/20 text-white max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{form.id ? "Edit Welcome Message" : "New Welcome Message"}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 mt-2">
+            <div>
+              <label className="block text-sm text-white/70 mb-1">Label (admin-only)</label>
+              <input
+                data-testid="welcome-label-input"
+                value={form.label}
+                onChange={(e) => setForm((f) => ({ ...f, label: e.target.value }))}
+                placeholder="e.g. Acme Corp visit"
+                className="w-full bg-transparent border border-white/20 px-3 py-2 text-sm focus:outline-none focus:border-white/60"
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-white/70 mb-1">
+                Slug{" "}
+                <span className="text-white/40">(URL key — lowercase alphanumeric and hyphens)</span>
+              </label>
+              <div className="flex items-center gap-2">
+                <span className="text-white/40 text-sm">?welcome=</span>
+                <input
+                  data-testid="welcome-slug-input"
+                  value={form.slug}
+                  onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value.toLowerCase() }))}
+                  placeholder="acme-corp"
+                  className="flex-1 bg-transparent border border-white/20 px-3 py-2 text-sm focus:outline-none focus:border-white/60"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm text-white/70 mb-1">
+                Welcome message{" "}
+                <span className="text-white/40">(newlines create separate typed lines)</span>
+              </label>
+              <textarea
+                data-testid="welcome-message-input"
+                value={form.message}
+                onChange={(e) => setForm((f) => ({ ...f, message: e.target.value }))}
+                placeholder={"Welcome to the team, Sarah!\nWe're glad you stopped by."}
+                rows={4}
+                className="w-full bg-transparent border border-white/20 px-3 py-2 text-sm focus:outline-none focus:border-white/60 resize-y font-mono"
+              />
+            </div>
+            <div className="flex gap-3 justify-end pt-2">
+              <button
+                onClick={() => setDialogOpen(false)}
+                className="px-4 py-2 text-sm border border-white/20 hover:border-white/40"
+              >
+                Cancel
+              </button>
+              <button
+                data-testid="save-welcome-message"
+                onClick={() => saveMutation.mutate()}
+                disabled={saveMutation.isPending || !form.slug || !form.label || !form.message}
+                className="px-4 py-2 text-sm border border-cyan-300/50 hover:border-cyan-300/80 disabled:opacity-40"
+              >
+                {saveMutation.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <DialogContent className="bg-black border border-white/20 text-white max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete Welcome Message</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-white/70 mt-2">
+            Permanently delete <span className="text-white font-mono">{deleteTarget?.slug}</span>?
+            This cannot be undone. The URL will stop working immediately.
+          </p>
+          <div className="flex gap-3 justify-end mt-4">
+            <button
+              onClick={() => setDeleteTarget(null)}
+              className="px-4 py-2 text-sm border border-white/20 hover:border-white/40"
+            >
+              Cancel
+            </button>
+            <button
+              data-testid="confirm-delete-welcome"
+              onClick={() => deleteTarget && deleteMutation.mutate(deleteTarget.id)}
+              disabled={deleteMutation.isPending}
+              className="px-4 py-2 text-sm border border-red-500/50 text-red-400 hover:border-red-500/80 disabled:opacity-40"
+            >
+              {deleteMutation.isPending ? "Deleting…" : "Delete"}
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+interface MessageCardProps {
+  msg: WelcomeMessage;
+  archived?: boolean;
+  onEdit: () => void;
+  onCopyUrl: () => void;
+  onArchive?: () => void;
+  onUnarchive?: () => void;
+  onDelete: () => void;
+}
+
+function MessageCard({ msg, archived, onEdit, onCopyUrl, onArchive, onUnarchive, onDelete }: MessageCardProps) {
+  const previewLines = msg.message.split("\n").slice(0, 2);
+  const hasMore = msg.message.split("\n").length > 2;
+
+  return (
+    <div
+      data-testid="welcome-message-card"
+      className={`border p-4 space-y-2 ${archived ? "border-white/10 opacity-60" : "border-white/20"}`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm">{msg.label}</span>
+            {archived && (
+              <span className="text-[10px] uppercase tracking-wider text-white/40 border border-white/20 px-1">
+                archived
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 mt-0.5">
+            <code className="text-xs text-cyan-300/80">?welcome={msg.slug}</code>
+            <button
+              onClick={onCopyUrl}
+              className="text-[10px] text-white/40 hover:text-white/70 underline"
+            >
+              copy URL
+            </button>
+          </div>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <button
+            onClick={onEdit}
+            className="text-xs border border-white/20 px-2 py-1 hover:border-white/40"
+          >
+            Edit
+          </button>
+          {!archived && onArchive && (
+            <button
+              onClick={onArchive}
+              className="text-xs border border-white/20 px-2 py-1 hover:border-white/40"
+            >
+              Archive
+            </button>
+          )}
+          {archived && onUnarchive && (
+            <button
+              onClick={onUnarchive}
+              className="text-xs border border-white/20 px-2 py-1 hover:border-white/40"
+            >
+              Restore
+            </button>
+          )}
+          <button
+            onClick={onDelete}
+            className="text-xs border border-red-500/30 text-red-400 px-2 py-1 hover:border-red-500/60"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+      <div className="text-sm text-white/50 font-mono">
+        {previewLines.map((line, i) => (
+          <div key={i}>{line}</div>
+        ))}
+        {hasMore && <div className="text-white/30">…</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/client/src/pages/Admin.tsx
+++ b/src/client/src/pages/Admin.tsx
@@ -6,13 +6,15 @@ import Footer from "@/components/Footer";
 import AdminBioPanel from "@/components/admin/AdminBioPanel";
 import AdminProjectsPanel from "@/components/admin/AdminProjectsPanel";
 import AdminSkillsPanel from "@/components/admin/AdminSkillsPanel";
+import AdminPersonalizationPanel from "@/components/admin/AdminPersonalizationPanel";
 
-type AdminTab = "bio" | "projects" | "skills";
+type AdminTab = "bio" | "projects" | "skills" | "personalization";
 
 const tabs: { id: AdminTab; label: string }[] = [
   { id: "bio", label: "Bio" },
   { id: "projects", label: "Projects" },
   { id: "skills", label: "Skills" },
+  { id: "personalization", label: "Personalization" },
 ];
 
 export default function Admin() {
@@ -86,6 +88,7 @@ export default function Admin() {
   const activePanel = useMemo(() => {
     if (activeTab === "projects") return <AdminProjectsPanel />;
     if (activeTab === "skills") return <AdminSkillsPanel />;
+    if (activeTab === "personalization") return <AdminPersonalizationPanel />;
     return <AdminBioPanel />;
   }, [activeTab]);
 
@@ -141,7 +144,7 @@ export default function Admin() {
       </div>
 
       <nav data-testid="admin-tabs" className="border border-white/10 p-2 bg-black/40 sticky top-2 z-10">
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-4 gap-2">
           {tabs.map((tab) => (
             <button
               key={tab.id}

--- a/src/migrations/0008_welcome_messages.sql
+++ b/src/migrations/0008_welcome_messages.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "welcome_messages" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "slug" text NOT NULL UNIQUE,
+  "label" text NOT NULL,
+  "message" text NOT NULL,
+  "archived_at" timestamp,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "welcome_messages_slug_idx" ON "welcome_messages"("slug");
+CREATE INDEX IF NOT EXISTS "welcome_messages_archived_at_idx" ON "welcome_messages"("archived_at");

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -346,3 +346,25 @@ export type BrowserTracking = typeof browserTracking.$inferSelect;
 export type BrowserTrackingIp = typeof browserTrackingIps.$inferSelect;
 export type BrowserRequestLog = typeof browserRequestLogs.$inferSelect;
 export type IpRateLog = typeof ipRateLogs.$inferSelect;
+
+// ─── Welcome Messages (Personalization) ──────────────────────────────────────
+
+export const welcomeMessages = pgTable("welcome_messages", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  slug: text("slug").notNull().unique(),
+  label: text("label").notNull(),
+  message: text("message").notNull(),
+  archivedAt: timestamp("archived_at"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const insertWelcomeMessageSchema = createInsertSchema(welcomeMessages).pick({
+  slug: true,
+  label: true,
+  message: true,
+});
+
+export const updateWelcomeMessageSchema = insertWelcomeMessageSchema.partial();
+
+export type WelcomeMessage = typeof welcomeMessages.$inferSelect;

--- a/src/tests/backend-unit/welcome-messages.test.ts
+++ b/src/tests/backend-unit/welcome-messages.test.ts
@@ -1,0 +1,81 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isValidWelcomeSlug, WELCOME_SLUG_MAX_LENGTH } from "../../backend/welcome-message-utils";
+
+// ── isValidWelcomeSlug ────────────────────────────────────────────────────────
+
+test("accepts simple lowercase slug", () => {
+  assert.equal(isValidWelcomeSlug("acme"), true);
+});
+
+test("accepts slug with hyphens", () => {
+  assert.equal(isValidWelcomeSlug("acme-corp"), true);
+});
+
+test("accepts slug with digits", () => {
+  assert.equal(isValidWelcomeSlug("acme2024"), true);
+});
+
+test("accepts single character slug", () => {
+  assert.equal(isValidWelcomeSlug("a"), true);
+});
+
+test("accepts slug with internal hyphens and digits", () => {
+  assert.equal(isValidWelcomeSlug("my-company-123"), true);
+});
+
+test("accepts max-length slug", () => {
+  const slug = "a".repeat(WELCOME_SLUG_MAX_LENGTH);
+  assert.equal(isValidWelcomeSlug(slug), true);
+});
+
+test("rejects empty string", () => {
+  assert.equal(isValidWelcomeSlug(""), false);
+});
+
+test("rejects slug that is too long", () => {
+  const slug = "a".repeat(WELCOME_SLUG_MAX_LENGTH + 1);
+  assert.equal(isValidWelcomeSlug(slug), false);
+});
+
+test("rejects slug with uppercase letters", () => {
+  assert.equal(isValidWelcomeSlug("Acme"), false);
+});
+
+test("rejects slug with leading hyphen", () => {
+  assert.equal(isValidWelcomeSlug("-acme"), false);
+});
+
+test("rejects slug with trailing hyphen", () => {
+  assert.equal(isValidWelcomeSlug("acme-"), false);
+});
+
+test("rejects slug with spaces", () => {
+  assert.equal(isValidWelcomeSlug("acme corp"), false);
+});
+
+test("rejects slug with special characters", () => {
+  assert.equal(isValidWelcomeSlug("acme@corp"), false);
+  assert.equal(isValidWelcomeSlug("acme.corp"), false);
+  assert.equal(isValidWelcomeSlug("acme/corp"), false);
+});
+
+test("rejects null", () => {
+  assert.equal(isValidWelcomeSlug(null), false);
+});
+
+test("rejects undefined", () => {
+  assert.equal(isValidWelcomeSlug(undefined), false);
+});
+
+test("rejects number", () => {
+  assert.equal(isValidWelcomeSlug(42), false);
+});
+
+test("rejects object", () => {
+  assert.equal(isValidWelcomeSlug({ slug: "acme" }), false);
+});
+
+test("rejects slug with consecutive hyphens", () => {
+  assert.equal(isValidWelcomeSlug("acme--corp"), false);
+});

--- a/src/tests/support/fixtures.ts
+++ b/src/tests/support/fixtures.ts
@@ -197,6 +197,27 @@ export const legalDocFixture = {
   effectiveDate: "March 27, 2026",
 };
 
+export const welcomeMessagesFixture = [
+  {
+    id: "wm-1",
+    slug: "test-org",
+    label: "Test Org Visit",
+    message: "Welcome, Test Org!\nWe're glad you stopped by.",
+    archivedAt: null,
+    createdAt: "2026-05-01T12:00:00.000Z",
+    updatedAt: "2026-05-01T12:00:00.000Z",
+  },
+  {
+    id: "wm-2",
+    slug: "acme-corp",
+    label: "Acme Corp Visit",
+    message: "Hi from Acme Corp!\nCheck out what we've built.",
+    archivedAt: null,
+    createdAt: "2026-05-10T08:00:00.000Z",
+    updatedAt: "2026-05-10T08:00:00.000Z",
+  },
+];
+
 export const adminFixtures = {
   me: {
     id: "admin-test-user",

--- a/src/tests/support/mock-api.ts
+++ b/src/tests/support/mock-api.ts
@@ -12,6 +12,7 @@ import {
   projectsFixture,
   promptSuggestionsFixture,
   skillsConstellationFixture,
+  welcomeMessagesFixture,
 } from "./fixtures";
 
 type JsonValue = unknown;
@@ -90,6 +91,23 @@ export async function installMockApi(page: Page) {
   );
   await page.route("**/api/public/linkedin/timeline?**", (route) =>
     fulfillJson(route, linkedinTimelineFixture),
+  );
+
+  await page.route("**/api/public/welcome-message?**", (route) => {
+    const url = new URL(route.request().url());
+    const slug = url.searchParams.get("welcome");
+    const match = welcomeMessagesFixture.find((m) => m.slug === slug);
+    if (match) {
+      return fulfillJson(route, { message: match.message });
+    }
+    return fulfillJson(route, { error: "Welcome message not found" }, 404);
+  });
+
+  await page.route("**/api/admin/welcome-messages/archived", (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route("**/api/admin/welcome-messages", (route) =>
+    fulfillJson(route, welcomeMessagesFixture),
   );
 
   await page.route("**/api/auth/me", (route) => fulfillJson(route, adminFixtures.me));

--- a/src/tests/ui-artifacts/viewport.spec.ts
+++ b/src/tests/ui-artifacts/viewport.spec.ts
@@ -36,6 +36,33 @@ test("first-visit-intro animation steps", async ({ page }, testInfo) => {
       state: { stage: "gap", typingPhase: "introPause" },
     },
     {
+      name: "welcome-cursor",
+      state: {
+        stage: "welcome",
+        typingPhase: "welcomePause",
+        welcomeMessage: "Hi from the team!\nWe're glad you stopped by.",
+        typedWelcomeText: "",
+      },
+    },
+    {
+      name: "welcome-typing",
+      state: {
+        stage: "welcome",
+        typingPhase: "welcomeTyping",
+        welcomeMessage: "Hi from the team!\nWe're glad you stopped by.",
+        typedWelcomeText: "Hi from the team!\nWe're glad",
+      },
+    },
+    {
+      name: "welcome-done",
+      state: {
+        stage: "welcome",
+        typingPhase: "welcomeDone",
+        welcomeMessage: "Hi from the team!\nWe're glad you stopped by.",
+        typedWelcomeText: "Hi from the team!\nWe're glad you stopped by.",
+      },
+    },
+    {
       name: "intro-cursor",
       state: { stage: "name", typingPhase: "introPause" },
     },
@@ -270,6 +297,15 @@ test("admin dashboard tabs", async ({ page }, testInfo) => {
   await expect(page.getByText("Skills CRUD")).toBeVisible();
   await settle(page, 700);
   await savePaginatedScreenshots(page, testInfo, "admin-dashboard/skills", {
+    maxPages: 4,
+    maxScrollDistance: 2_800,
+  });
+
+  await page.getByTestId("admin-tab-personalization").click();
+  await expect(page.getByRole("heading", { name: "Welcome Messages" })).toBeVisible();
+  await expect(page.getByTestId("admin-personalization-panel")).toBeVisible();
+  await settle(page, 700);
+  await savePaginatedScreenshots(page, testInfo, "admin-dashboard/personalization", {
     maxPages: 4,
     maxScrollDistance: 2_800,
   });

--- a/src/tests/ui-test/personalization.spec.ts
+++ b/src/tests/ui-test/personalization.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "@playwright/test";
+import { installMockApi, seedBrowserState } from "../support/mock-api";
+
+const FORCE_SHOW_KEY = "__intro_force_show";
+const WELCOME_SLUG_KEY = "__intro_welcome_slug";
+const INTRO_SEEN_KEY = "__root_intro_seen_until";
+
+async function setup(page: import("@playwright/test").Page, consent: "accept_all" | "reject_all" | "none" = "reject_all") {
+  await installMockApi(page);
+  await seedBrowserState(page, {
+    introSeen: true,
+    consent,
+    logRocketTestMode: true,
+  });
+}
+
+// ── ?welcome= query param processing ─────────────────────────────────────────
+
+test("?welcome= param is stripped from URL after page load", async ({ page }) => {
+  await setup(page);
+  await page.goto("/?welcome=acme-corp");
+
+  await page.waitForURL((url) => !url.searchParams.has("welcome"), { timeout: 5000 });
+  expect(page.url()).not.toContain("welcome=");
+});
+
+test("?welcome= param stores slug in localStorage", async ({ page }) => {
+  await setup(page);
+
+  // Intercept the reload to check localStorage before it navigates away
+  await page.addInitScript(() => {
+    const origReplace = window.location.replace.bind(window.location);
+    (window.location as any).replace = (url: string) => {
+      // Store signal before replace fires
+      (window as any).__welcomeReplaceTarget = url;
+      origReplace(url);
+    };
+  });
+
+  await page.goto("/?welcome=acme-corp");
+  await page.waitForURL((url) => !url.searchParams.has("welcome"), { timeout: 5000 });
+
+  // After reload: slug should be in localStorage
+  const slug = await page.evaluate((key) => window.localStorage.getItem(key), WELCOME_SLUG_KEY);
+  expect(slug).toBe("acme-corp");
+});
+
+test("?welcome= param sets the force-show flag in localStorage", async ({ page }) => {
+  await setup(page);
+  await page.goto("/?welcome=acme-corp");
+  await page.waitForURL((url) => !url.searchParams.has("welcome"), { timeout: 5000 });
+
+  const flag = await page.evaluate((key) => window.localStorage.getItem(key), FORCE_SHOW_KEY);
+  expect(flag).toBe("1");
+});
+
+test("?welcome= preserves other query params", async ({ page }) => {
+  await setup(page);
+  await page.goto("/?keep=yes&welcome=acme-corp");
+
+  await page.waitForURL((url) => !url.searchParams.has("welcome"), { timeout: 5000 });
+  const url = new URL(page.url());
+  expect(url.searchParams.has("welcome")).toBe(false);
+  expect(url.searchParams.get("keep")).toBe("yes");
+});
+
+// ── Force-show flag overrides TTL ─────────────────────────────────────────────
+
+test("intro shows when force-show flag is set even if TTL is active", async ({ page }) => {
+  await installMockApi(page);
+  await page.addInitScript((keys) => {
+    Math.random = () => 0.42;
+    window.__LOGROCKET_TEST_MODE = true;
+    window.__LOGROCKET_TEST_EVENTS = [];
+    // TTL valid (seen recently)
+    window.localStorage.setItem(keys.seenKey, String(Date.now() + 3 * 24 * 60 * 60 * 1000));
+    // Force-show override
+    window.localStorage.setItem(keys.forceKey, "1");
+    window.localStorage.removeItem("__consent_record");
+  }, { seenKey: INTRO_SEEN_KEY, forceKey: FORCE_SHOW_KEY });
+
+  await page.goto("/");
+  await expect(page.getByTestId("first-visit-intro")).toBeVisible({ timeout: 5000 });
+});
+
+test("intro does NOT show when force-show flag is absent and TTL is active", async ({ page }) => {
+  await setup(page);
+  // introSeen: true from seedBrowserState — TTL is valid, no force-show flag
+  await page.goto("/");
+  await expect(page.getByTestId("first-visit-intro")).not.toBeVisible({ timeout: 3000 });
+});
+
+// ── Admin personalization panel ───────────────────────────────────────────────
+
+test("admin personalization tab is visible and shows welcome messages list", async ({ page }) => {
+  await setup(page);
+  await page.goto("/admin");
+  await expect(page.getByRole("heading", { name: "Admin Dashboard" })).toBeVisible({ timeout: 15_000 });
+
+  await page.getByTestId("admin-tab-personalization").click();
+  await expect(page.getByRole("heading", { name: "Welcome Messages" })).toBeVisible();
+  await expect(page.getByTestId("admin-personalization-panel")).toBeVisible();
+});
+
+test("admin personalization panel renders message cards from mock data", async ({ page }) => {
+  await setup(page);
+  await page.goto("/admin");
+  await page.getByTestId("admin-tab-personalization").click();
+
+  await expect(page.getByText("Test Org Visit")).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText("Acme Corp Visit")).toBeVisible();
+});
+
+test("clicking + New Message opens the create dialog", async ({ page }) => {
+  await setup(page);
+  await page.goto("/admin");
+  await page.getByTestId("admin-tab-personalization").click();
+  await page.getByTestId("create-welcome-message").click();
+
+  await expect(page.getByTestId("welcome-label-input")).toBeVisible();
+  await expect(page.getByTestId("welcome-slug-input")).toBeVisible();
+  await expect(page.getByTestId("welcome-message-input")).toBeVisible();
+});
+
+test("save button is disabled when form fields are empty", async ({ page }) => {
+  await setup(page);
+  await page.goto("/admin");
+  await page.getByTestId("admin-tab-personalization").click();
+  await page.getByTestId("create-welcome-message").click();
+
+  const saveBtn = page.getByTestId("save-welcome-message");
+  await expect(saveBtn).toBeDisabled();
+});
+
+test("copy URL button copies the welcome URL to clipboard", async ({ page, context }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await setup(page);
+  await page.goto("/admin");
+  await page.getByTestId("admin-tab-personalization").click();
+
+  // Click the copy URL link for the first message card
+  const copyBtn = page.getByText("copy URL").first();
+  await expect(copyBtn).toBeVisible({ timeout: 5000 });
+  await copyBtn.click();
+
+  const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboardText).toContain("?welcome=test-org");
+});
+
+// ── Welcome message API error handling ───────────────────────────────────────
+
+test("non-existent welcome slug in URL still strips param and does not crash", async ({ page }) => {
+  await setup(page);
+  // no-slug: slug that won't match any fixture
+  await page.goto("/?welcome=does-not-exist");
+  await page.waitForURL((url) => !url.searchParams.has("welcome"), { timeout: 5000 });
+  // Page should render normally (no crash), force-show flag should still be set
+  const flag = await page.evaluate((key) => window.localStorage.getItem(key), FORCE_SHOW_KEY);
+  expect(flag).toBe("1");
+});


### PR DESCRIPTION
- DB: new welcome_messages table (slug, label, message, archived_at) with migration 0008
- Backend: public GET /api/public/welcome-message?welcome=<slug> for lookup; full admin CRUD (/api/admin/welcome-messages) with archive/unarchive/hard-delete
- App: WelcomeProcessor strips ?welcome=<slug> from URL, stores slug + force-show flag in localStorage, then reloads so the intro TTL override takes effect
- FirstVisitIntro: new "welcome" stage types the admin message char-by-char (with extra pause on newlines) between the phrase and name stages; force-show flag cleared on intro complete; welcomeMessage prop received from App
- Admin dashboard: new Personalization tab (4-column tab grid) with AdminPersonalizationPanel — CRUD list, create/edit dialog, archive/restore, copy-URL per entry
- Tests: 18 backend unit tests for slug validation, 12 UI tests for QP processing + force-show override + admin panel, artifact tests updated with 3 welcome-stage states and personalization tab screenshot

https://claude.ai/code/session_01GgdrPDkXfexr7C3UrvKqmH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added personalized welcome messages for first-time visitors with customizable, character-by-character typing animation.
  * Introduced admin panel to create, edit, archive, and manage welcome messages.
  * Enabled shareable welcome links via URL parameters for personalized visitor greetings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matt2jog/portfolio/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->