### PR TITLE
Unify legacy Admin with shared OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,8 @@ ENFORCE_US_ONLY=true
 # into resume_vcs_cloud/certs/kafka-ca.pem; it is a public CA cert, safe to copy inline).
 # KAFKA_CA_CERT_PATH=./certs/kafka-ca.pem
 # KAFKA_CA_CERT="-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+ADMIN_AUTHORITY_URL=https://admin.2jog.dev
+ADMIN_IDENTITY_ISSUER=https://admin.2jog.dev
+ADMIN_IDENTITY_AUDIENCE=2jog-services
+ADMIN_IDENTITY_JWKS_URL=https://admin.2jog.dev/.well-known/jwks.json
+PUBLIC_BASE_URL=https://2jog.dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "geoip-lite": "^1.4.10",
         "gsap": "^3.14.2",
         "input-otp": "^1.4.2",
+        "jose": "^6.2.3",
         "jsdom": "^29.0.1",
         "kafkajs": "^2.2.4",
         "katex": "^0.16.44",
@@ -10052,6 +10053,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jpeg-js": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "legal:record": "tsx --env-file=.env src/scripts/legal/record-versions.ts"
   },
   "dependencies": {
-    "@infisical/sdk": "^5.0.2",
     "@hookform/resolvers": "^3.10.0",
+    "@infisical/sdk": "^5.0.2",
     "@jridgewell/trace-mapping": "^0.3.25",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -68,6 +68,7 @@
     "geoip-lite": "^1.4.10",
     "gsap": "^3.14.2",
     "input-otp": "^1.4.2",
+    "jose": "^6.2.3",
     "jsdom": "^29.0.1",
     "kafkajs": "^2.2.4",
     "katex": "^0.16.44",

--- a/src/backend/auth.ts
+++ b/src/backend/auth.ts
@@ -1,201 +1,149 @@
 import type { Express, NextFunction, Request, RequestHandler, Response } from "express";
-import session from "express-session";
-import passport from "passport";
-import { Strategy as GoogleStrategy } from "passport-google-oauth20";
-import connectPgSimple from "connect-pg-simple";
-import { db, pool } from "./data/db";
+import { createRemoteJWKSet, jwtVerify, type JWTVerifyGetKey, type JWTPayload } from "jose";
+import { eq, or } from "drizzle-orm";
+import { db } from "./data/db";
 import { users } from "@shared/schema";
-import { eq } from "drizzle-orm";
-import { parseCookies } from "./tracking-utils";
 
-const PgSession = connectPgSimple(session);
-
-const splitList = (value?: string) =>
-  value
-    ?.split(",")
-    .map((item) => item.trim())
-    .filter(Boolean) ?? [];
-
-const allowedAdminEmails = splitList(process.env.ALLOWED_ADMIN_EMAIL);
-const allowedAdminSubs = splitList(process.env.ALLOWED_ADMIN_SUB);
+export const ADMIN_IDENTITY_COOKIE = "__Secure-2jog-admin";
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 const isProd = process.env.NODE_ENV === "production";
-const sessionSecret = process.env.SESSION_SECRET;
-const googleClientId = process.env.GOOGLE_CLIENT_ID;
-const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
-const callbackUrl = process.env.CALLBACK_URL || process.env.CALLBACK_URL_FALLBACK;
-const sessionCookieDomain = process.env.SESSION_COOKIE_DOMAIN || (isProd ? ".2jog.dev" : undefined);
-const RESUME_RETURN_COOKIE = "resume_return";
-const RESUME_RETURN_ORIGIN = "https://resume.2jog.dev";
+const authorityUrl = process.env.ADMIN_AUTHORITY_URL || (isProd ? "https://admin.2jog.dev" : "http://localhost:8080");
+const identityIssuer = process.env.ADMIN_IDENTITY_ISSUER || authorityUrl;
+const identityAudience = process.env.ADMIN_IDENTITY_AUDIENCE || "2jog-services";
+const identityJwksUrl = process.env.ADMIN_IDENTITY_JWKS_URL || new URL("/.well-known/jwks.json", authorityUrl).toString();
+const publicOrigin = process.env.PUBLIC_BASE_URL || (isProd ? "https://2jog.dev" : "http://localhost:3000");
+const keySet = createRemoteJWKSet(new URL(identityJwksUrl));
 
 if (isProd) {
-  if (!sessionSecret) {
-    throw new Error("SESSION_SECRET is required in production");
-  }
-  if (!googleClientId || !googleClientSecret || !callbackUrl) {
-    throw new Error("GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and CALLBACK_URL are required in production");
+  for (const [name, value] of Object.entries({
+    ADMIN_AUTHORITY_URL: process.env.ADMIN_AUTHORITY_URL,
+    ADMIN_IDENTITY_ISSUER: process.env.ADMIN_IDENTITY_ISSUER,
+    ADMIN_IDENTITY_AUDIENCE: process.env.ADMIN_IDENTITY_AUDIENCE,
+    ADMIN_IDENTITY_JWKS_URL: process.env.ADMIN_IDENTITY_JWKS_URL,
+    PUBLIC_BASE_URL: process.env.PUBLIC_BASE_URL,
+  })) {
+    if (!value) throw new Error(`${name} is required in production`);
   }
 }
 
-const isAllowedAdmin = (email?: string | null, sub?: string | null) => {
-  if (sub && allowedAdminSubs.includes(sub)) return true;
-  if (email && allowedAdminEmails.includes(email)) return true;
-  return false;
-};
+interface AdminClaims extends JWTPayload {
+  email: string;
+  role: "admin";
+}
 
-export function setupAuth(app: Express) {
+function parseCookies(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  return Object.fromEntries(raw.split(";").flatMap((part) => {
+    const separator = part.indexOf("=");
+    if (separator < 0) return [];
+    const name = part.slice(0, separator).trim();
+    const value = part.slice(separator + 1).trim();
+    return name ? [[name, value]] : [];
+  }));
+}
+
+export async function verifyAdminIdentity(token: string, verificationKeySet: JWTVerifyGetKey = keySet): Promise<AdminClaims> {
+  const { payload, protectedHeader } = await jwtVerify(token, verificationKeySet, {
+    algorithms: ["RS256"],
+    issuer: identityIssuer,
+    audience: identityAudience,
+    clockTolerance: 30,
+  });
+  if (protectedHeader.typ !== "JWT" || !protectedHeader.kid || Object.keys(protectedHeader).sort().join(",") !== "alg,kid,typ") {
+    throw new Error("Invalid Admin identity header");
+  }
+  if (!payload.sub || typeof payload.email !== "string" || payload.email !== payload.email.toLowerCase() || payload.role !== "admin") {
+    throw new Error("Invalid Admin identity claims");
+  }
+  if (typeof payload.iat !== "number" || typeof payload.exp !== "number" || typeof payload.jti !== "string" || !UUID_V4.test(payload.jti)) {
+    throw new Error("Invalid Admin identity lifetime");
+  }
+  if (payload.exp - payload.iat !== 900) throw new Error("Admin identity lifetime must be 15 minutes");
+  return payload as AdminClaims;
+}
+
+async function localAdmin(claims: AdminClaims): Promise<Express.User> {
+  const email = claims.email.trim().toLowerCase();
+  const [existing] = await db.select().from(users).where(or(eq(users.googleSub, claims.sub!), eq(users.email, email))).limit(1);
+  if (existing) {
+    const [updated] = await db.update(users).set({ googleSub: claims.sub!, email, role: "admin" }).where(eq(users.id, existing.id)).returning();
+    return updated!;
+  }
+  const [created] = await db.insert(users).values({ email, googleSub: claims.sub!, role: "admin", name: null }).returning();
+  return created!;
+}
+
+export function setupAuth(app: Express): void {
   app.set("trust proxy", 1);
-
-  app.use(
-    session({
-      secret: sessionSecret || "dev-secret",
-      resave: false,
-      saveUninitialized: false,
-      store: new PgSession({
-        pool,
-        tableName: "session",
-        schemaName: "public",
-      }),
-      cookie: {
-        httpOnly: true,
-        domain: sessionCookieDomain,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-      },
-    })
-  );
-
-  app.use(passport.initialize());
-  app.use(passport.session());
-
-  passport.serializeUser((user, done) => {
-    done(null, user.id);
-  });
-
-  passport.deserializeUser(async (id: string, done) => {
+  app.use(async (req, _res, next) => {
+    const token = parseCookies(req.headers.cookie)[ADMIN_IDENTITY_COOKIE];
+    if (!token) return next();
     try {
-      const [user] = await db.select().from(users).where(eq(users.id, id));
-      done(null, user || null);
-    } catch (error) {
-      done(error);
+      req.user = await localAdmin(await verifyAdminIdentity(token));
+    } catch {
+      req.user = undefined;
     }
+    return next();
   });
-
-  passport.use(
-    new GoogleStrategy(
-      {
-        clientID: googleClientId || "",
-        clientSecret: googleClientSecret || "",
-        callbackURL: callbackUrl || "",
-      },
-      async (_accessToken, _refreshToken, profile, done) => {
-        try {
-          const email = profile.emails?.[0]?.value ?? null;
-          const sub = profile.id ?? null;
-          const name = profile.displayName ?? null;
-
-          if (!isAllowedAdmin(email, sub)) {
-            return done(null, false);
-          }
-
-          const [existing] = await db
-            .select()
-            .from(users)
-            .where(eq(users.googleSub, sub));
-
-          if (existing) {
-            const updates: { email?: string; name?: string | null } = {};
-            if (email && existing.email !== email) {
-              updates.email = email;
-            }
-            if (existing.name !== name) {
-              updates.name = name;
-            }
-
-            if (Object.keys(updates).length > 0) {
-              await db
-                .update(users)
-                .set(updates)
-                .where(eq(users.id, existing.id));
-            }
-            return done(null, existing);
-          }
-
-          const [created] = await db
-            .insert(users)
-            .values({
-              email: email || "",
-              googleSub: sub || "",
-              name,
-              role: "admin",
-            })
-            .returning();
-
-          return done(null, created);
-        } catch (error) {
-          return done(error as Error);
-        }
-      }
-    )
-  );
 }
 
 export const requireAuth: RequestHandler = (req, res, next) => {
-  if (req.isAuthenticated && req.isAuthenticated()) {
-    return next();
-  }
-  return res.status(401).json({ message: "Unauthorized" });
+  if (req.user) return next();
+  return res.status(401).json({
+    message: "Unauthorized",
+    login_url: buildAdminLoginUrl(requestReturn(req)),
+  });
 };
 
 export const requireAdmin: RequestHandler = (req, res, next) => {
-  if (req.isAuthenticated && req.isAuthenticated() && req.user?.role === "admin") {
-    return next();
-  }
-  return res.status(403).json({ message: "Forbidden" });
+  if (req.user?.role === "admin") return next();
+  return res.status(401).json({
+    message: "Unauthorized",
+    login_url: buildAdminLoginUrl(requestReturn(req)),
+  });
 };
 
-const getResumeReturnFromCookie = (headersCookie: string | undefined): string | undefined => {
-  const candidate = parseCookies(headersCookie)[RESUME_RETURN_COOKIE];
-  if (!candidate) return undefined;
-
-  try {
-    const parsed = new URL(candidate);
-    return parsed.origin === RESUME_RETURN_ORIGIN ? parsed.toString() : undefined;
-  } catch {
-    return undefined;
+export function normalizePortfolioReturn(requested?: string): string {
+  if (requested) {
+    try {
+      const parsed = new URL(requested);
+      if (parsed.origin === new URL(publicOrigin).origin && (parsed.pathname === "/admin" || parsed.pathname.startsWith("/admin/"))) {
+        return parsed.toString();
+      }
+    } catch {
+      // Fall back to the canonical legacy Admin page.
+    }
   }
-};
+  return new URL("/admin", publicOrigin).toString();
+}
+
+export function buildAdminLoginUrl(returnTo: string): string {
+  const login = new URL("/auth/google", authorityUrl);
+  login.searchParams.set("returnTo", returnTo);
+  return login.toString();
+}
+
+function requestReturn(req: Request): string {
+  const referer = req.get("referer");
+  return normalizePortfolioReturn(referer);
+}
 
 export const authRoutes = {
-  start: passport.authenticate("google", { scope: ["profile", "email"] }),
-  callback: (req: Request, res: Response, next: NextFunction) => {
-    return passport.authenticate("google", (error: unknown, user: Express.User | false | null, _info: unknown) => {
-      if (error) return next(error);
-      if (!user) return res.redirect("/?auth=denied");
-
-      req.login(user, (loginError: unknown) => {
-        if (loginError) return next(loginError);
-
-        const resumeReturn = getResumeReturnFromCookie(req.headers.cookie);
-        if (resumeReturn) {
-          res.clearCookie(RESUME_RETURN_COOKIE, {
-            path: "/",
-            httpOnly: false,
-            sameSite: "lax",
-            secure: isProd,
-            domain: sessionCookieDomain,
-          });
-          return res.redirect(resumeReturn);
-        }
-
-        return res.status(404).json({ error: "Missing resume return target" });
-      });
-    })(req, res, next);
+  start: (req: Request, res: Response) => res.redirect(302, buildAdminLoginUrl(normalizePortfolioReturn(typeof req.query.returnTo === "string" ? req.query.returnTo : undefined))),
+  callback: (req: Request, res: Response) => res.redirect(302, buildAdminLoginUrl(normalizePortfolioReturn(typeof req.query.returnTo === "string" ? req.query.returnTo : undefined))),
+  logout: (_req: Request, res: Response) => {
+    const logout = new URL("/auth/logout", authorityUrl);
+    logout.searchParams.set("returnTo", new URL("/", publicOrigin).toString());
+    return res.json({ ok: true, logout_url: logout.toString() });
   },
 };
 
 declare global {
   namespace Express {
+    interface Request {
+      user?: User;
+    }
     interface User {
       id: string;
       email: string;

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -213,9 +213,7 @@ export async function registerRoutes(
   });
 
   app.post("/api/auth/logout", (req, res) => {
-    req.logout(() => {
-      res.json({ ok: true });
-    });
+    return authRoutes.logout(req, res);
   });
 
   // ========== LEGAL DOCUMENTS ==========

--- a/src/client/src/lib/queryClient.ts
+++ b/src/client/src/lib/queryClient.ts
@@ -4,6 +4,21 @@ import { getClientIp } from "./tracking";
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
+    if (res.status === 401) {
+      try {
+        const loginUrl = (JSON.parse(text) as { login_url?: unknown }).login_url;
+        if (typeof loginUrl === "string") {
+          const parsed = new URL(loginUrl);
+          const safeScheme = parsed.protocol === "https:" || (parsed.protocol === "http:" && parsed.hostname === "localhost");
+          if (safeScheme && parsed.pathname === "/auth/google" && parsed.searchParams.has("returnTo")) {
+            window.location.assign(parsed.toString());
+            throw new Error("Redirecting to sign in");
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message === "Redirecting to sign in") throw error;
+      }
+    }
     throw new Error(`${res.status}: ${text}`);
   }
 }

--- a/src/client/src/pages/Admin.tsx
+++ b/src/client/src/pages/Admin.tsx
@@ -136,7 +136,10 @@ export default function Admin() {
       <div className="flex items-center justify-between gap-3">
         <h1 className="text-2xl sm:text-3xl font-bold">Admin Dashboard</h1>
         <button
-          onClick={() => apiRequest("POST", "/api/auth/logout").then(() => window.location.reload())}
+          onClick={() => apiRequest("POST", "/api/auth/logout").then(async (response) => {
+            const body = await response.json() as { logout_url?: string };
+            window.location.assign(body.logout_url || "/");
+          })}
           className="px-4 py-2 border border-white/20 text-white hover:border-white/60"
         >
           Log out

--- a/src/tests/backend-unit/admin-sso.test.ts
+++ b/src/tests/backend-unit/admin-sso.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose";
+
+process.env.NODE_ENV = "test";
+process.env.ADMIN_AUTHORITY_URL = "https://admin.2jog.dev";
+process.env.ADMIN_IDENTITY_ISSUER = "https://admin.2jog.dev";
+process.env.ADMIN_IDENTITY_AUDIENCE = "2jog-services";
+process.env.ADMIN_IDENTITY_JWKS_URL = "https://admin.2jog.dev/.well-known/jwks.json";
+process.env.PUBLIC_BASE_URL = "https://2jog.dev";
+process.env.DATABASE_URL ||= "postgresql://test:test@localhost:5432/test";
+
+const { buildAdminLoginUrl, normalizePortfolioReturn, verifyAdminIdentity } = await import("../../backend/auth");
+
+test("legacy Admin return targets preserve an exact local path and query", () => {
+  assert.equal(
+    normalizePortfolioReturn("https://2jog.dev/admin/projects?view=archived&sort=recent"),
+    "https://2jog.dev/admin/projects?view=archived&sort=recent",
+  );
+  assert.equal(normalizePortfolioReturn("https://attacker.example/admin"), "https://2jog.dev/admin");
+  assert.equal(normalizePortfolioReturn("https://2jog.dev/not-admin"), "https://2jog.dev/admin");
+  assert.equal(
+    buildAdminLoginUrl("https://2jog.dev/admin?tab=projects"),
+    "https://admin.2jog.dev/auth/google?returnTo=https%3A%2F%2F2jog.dev%2Fadmin%3Ftab%3Dprojects",
+  );
+});
+
+test("shared Admin identity pins RS256 issuer audience and required claims", async () => {
+  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "portfolio-test";
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+  const now = Math.floor(Date.now() / 1000);
+  const token = await new SignJWT({ email: "matthewtujague@gmail.com", role: "admin" })
+    .setProtectedHeader({ alg: "RS256", typ: "JWT", kid: jwk.kid })
+    .setIssuer("https://admin.2jog.dev")
+    .setAudience("2jog-services")
+    .setSubject("google-sub")
+    .setJti("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+    .setIssuedAt(now)
+    .setExpirationTime(now + 900)
+    .sign(privateKey);
+  const keys = createLocalJWKSet({ keys: [jwk] });
+
+  await assert.doesNotReject(() => verifyAdminIdentity(token, keys));
+  const wrongAudience = await new SignJWT({ email: "matthewtujague@gmail.com", role: "admin" })
+    .setProtectedHeader({ alg: "RS256", typ: "JWT", kid: jwk.kid })
+    .setIssuer("https://admin.2jog.dev")
+    .setAudience("wrong")
+    .setSubject("google-sub")
+    .setJti("550e8400-e29b-41d4-a716-446655440000")
+    .setIssuedAt(now)
+    .setExpirationTime(now + 900)
+    .sign(privateKey);
+  await assert.rejects(() => verifyAdminIdentity(wrongAudience, keys));
+});


### PR DESCRIPTION
## Summary
- replace Portfolio-owned Google OAuth with Admin-issued RS256 identity validation
- preserve exact /admin return paths and queries
- centralize logout and remove duplicate OAuth secret ownership
- retain only local user projection for existing Portfolio authorization/FKs

## Verification
- npm run check
- 49 non-database backend unit tests passed (live DB tests require the production test DB)
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced JWT-based admin authentication with secure identity validation.
  * Added configurable admin login, logout, issuer, audience, and public URL settings.
  * Admin login now supports safe return URLs and redirects to the appropriate authentication flow.
  * Logout now redirects through the configured sign-out destination.

* **Bug Fixes**
  * Unauthorized requests now provide a login link and consistent response status.

* **Tests**
  * Added coverage for secure token validation and return URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->