### PR TITLE
Fix Portfolio Cloud Run deploy flags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,5 @@ jobs:
             --max-instances 1 \
             --cpu 1 \
             --memory 512Mi \
-            --clear-env-vars \
-            --clear-secrets \
             --set-env-vars "INFISICAL_PROJECT_ID=$INFISICAL_PROJECT_ID,INFISICAL_ENV=$INFISICAL_ENV" \
             --set-secrets "INFISICAL_TOKEN=infisical-runtime-token:latest"


### PR DESCRIPTION
Removes mutually exclusive clear flags from the Cloud Run deploy command. The set operations already replace the environment and secret mappings. This unblocks deployment of the merged unified OAuth integration.