### PR TITLE
Fix release image Trivy severity gates

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -64,12 +64,22 @@ jobs:
           severity: HIGH
           format: table
           exit-code: "0"
-      - name: Block Critical vulnerabilities and secrets
+      - name: Block Critical vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ env.IMAGE_REPOSITORY }}:${{ github.sha }}
-          scanners: vuln,secret
+          scanners: vuln
+          severity: CRITICAL
+          format: table
+          exit-code: "1"
+          skip-setup-trivy: true
+      - name: Block detected secrets
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ env.IMAGE_REPOSITORY }}:${{ github.sha }}
+          scanners: secret
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           format: table
           exit-code: "1"

--- a/src/tests/backend-unit/delivery-policy.test.ts
+++ b/src/tests/backend-unit/delivery-policy.test.ts
@@ -514,6 +514,20 @@ test("fork-safe pull request CI exercises coverage, integration, UI, build, and 
   }
 });
 
+test("release-image security gates block only Critical vulnerabilities and all detected secrets", () => {
+  const workflow = read(".github/workflows/release-image.yml");
+
+  assert.doesNotMatch(workflow, /scanners:\s*vuln,secret/);
+  assert.match(
+    workflow,
+    /name:\s*Block Critical vulnerabilities[\s\S]*?scanners:\s*vuln[\s\S]*?severity:\s*CRITICAL[\s\S]*?exit-code:\s*["']1["']/,
+  );
+  assert.match(
+    workflow,
+    /name:\s*Block detected secrets[\s\S]*?scanners:\s*secret[\s\S]*?severity:\s*UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL[\s\S]*?exit-code:\s*["']1["']/,
+  );
+});
+
 test("main delivery uses repository-bound WIF, a dedicated registry, digest pinning, and causal rollback", () => {
   const workflow = read(".github/workflows/deploy.yml");
   const release = read(".github/scripts/deploy-cloud-run.sh");


### PR DESCRIPTION
Splits the release-image security gate so Critical vulnerabilities block independently from detected secrets. Adds a regression policy test reproducing the failed main run. No application or cloud resource changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release security checks by separately blocking critical vulnerabilities and detected secrets.
  * Preserved high-severity security reporting while making release-blocking conditions more precise.

* **Tests**
  * Added automated coverage to verify the release workflow enforces both security gates independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->