### PR TITLE
Isolate Portfolio Infisical sources

### DIFF
--- a/config/secret-schema.prod.json
+++ b/config/secret-schema.prod.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "service": "portfolio",
   "environment": "prod",
+  "infisical_path": "/services/portfolio",
   "bundles": {
     "database_bootstrap": {
       "target_secret": "portfolio-database-bootstrap-bundle-prod",
@@ -20,18 +21,18 @@
     "runtime": {
       "target_secret": "portfolio-runtime-bundle-prod",
       "fields": {
-        "ADMIN_AUTHORITY_URL": {"source": "ADMIN_AUTHORITY_URL", "type": "https_url", "required": true},
-        "ADMIN_IDENTITY_AUDIENCE": {"source": "ADMIN_IDENTITY_AUDIENCE", "type": "string", "required": true},
-        "ADMIN_IDENTITY_ISSUER": {"source": "ADMIN_IDENTITY_ISSUER", "type": "https_url", "required": true},
-        "ADMIN_IDENTITY_JWKS_URL": {"source": "ADMIN_IDENTITY_JWKS_URL", "type": "https_url", "required": true},
+        "ADMIN_AUTHORITY_URL": {"source": "PORTFOLIO_ADMIN_AUTHORITY_URL", "type": "https_url", "required": true},
+        "ADMIN_IDENTITY_AUDIENCE": {"source": "PORTFOLIO_ADMIN_IDENTITY_AUDIENCE", "type": "string", "required": true},
+        "ADMIN_IDENTITY_ISSUER": {"source": "PORTFOLIO_ADMIN_IDENTITY_ISSUER", "type": "https_url", "required": true},
+        "ADMIN_IDENTITY_JWKS_URL": {"source": "PORTFOLIO_ADMIN_IDENTITY_JWKS_URL", "type": "https_url", "required": true},
         "CAREER_PUBSUB_PUSH_AUDIENCE": {"source": "PORTFOLIO_CAREER_PUBSUB_PUSH_AUDIENCE", "type": "https_url", "required": true},
         "CAREER_PUBSUB_PUSH_SERVICE_ACCOUNT": {"source": "PORTFOLIO_CAREER_PUBSUB_PUSH_SERVICE_ACCOUNT", "type": "string", "required": true, "pattern": "^[a-z0-9][a-z0-9-]{2,62}@[a-z0-9-]+\\.iam\\.gserviceaccount\\.com$"},
         "CAREER_PUBSUB_SUBSCRIPTION": {"source": "PORTFOLIO_CAREER_PUBSUB_SUBSCRIPTION", "type": "string", "required": true, "pattern": "^projects\\/[a-z][a-z0-9-]{4,28}[a-z0-9]\\/subscriptions\\/[A-Za-z][A-Za-z0-9._~+%-]{2,254}$"},
         "DATABASE_URL": {"source": "PORTFOLIO_RUNTIME_DATABASE_URL", "type": "uri", "required": true},
         "EDGE_ORIGIN_TOKEN": {"source": "PORTFOLIO_EDGE_ORIGIN_TOKEN", "type": "string", "required": true, "min_length": 32, "max_length": 256, "pattern": "^[A-Za-z0-9_-]+$"},
         "EDGE_ORIGIN_PREVIOUS_TOKEN": {"source": "PORTFOLIO_EDGE_ORIGIN_PREVIOUS_TOKEN", "type": "string", "required": false, "min_length": 32, "max_length": 256, "pattern": "^[A-Za-z0-9_-]+$"},
-        "FIREWORKS_AI_TOKEN": {"source": "FIREWORKS_AI_TOKEN", "type": "string", "required": true},
-        "GRADIENT_AI_TOKEN": {"source": "GRADIENT_AI_TOKEN", "type": "string", "required": true},
+        "FIREWORKS_AI_TOKEN": {"source": "PORTFOLIO_FIREWORKS_AI_TOKEN", "type": "string", "required": true},
+        "GRADIENT_AI_TOKEN": {"source": "PORTFOLIO_GRADIENT_AI_TOKEN", "type": "string", "required": true},
         "SUPABASE_CA_CERT": {"source": "PORTFOLIO_SUPABASE_CA_CERT", "type": "pem", "required": true},
         "SUPABASE_CA_SHA256": {"source": "PORTFOLIO_SUPABASE_CA_SHA256", "type": "string", "required": true, "pattern": "^[a-f0-9]{64}$"},
         "SUPABASE_PROJECT_REF": {"source": "PORTFOLIO_SUPABASE_PROJECT_REF", "type": "string", "required": true, "pattern": "^qvbpgvazqfyhwjsfulsb$"}


### PR DESCRIPTION
## What changed

- declares the canonical Portfolio Infisical folder
- replaces shared Admin identity and inference-provider source names with Portfolio-owned records

## Why

Portfolio and Resume may hold equivalent provider values, but neither service may double-dip into a shared source record.

## Validation

- Portfolio ephemeral bundle test passed
- root normalized schema-copy and ownership tests passed